### PR TITLE
[codex] Brain Admin Refresh

### DIFF
--- a/app/admin/brain/Brain.module.css
+++ b/app/admin/brain/Brain.module.css
@@ -1,50 +1,171 @@
 .brainPage {
+  --brain-bg: #edf2fb;
+  --brain-bg-alt: #fbfcff;
+  --brain-panel-bg: rgba(255, 255, 255, 0.78);
+  --brain-panel-strong: rgba(255, 255, 255, 0.92);
+  --brain-panel-muted: rgba(255, 255, 255, 0.64);
+  --brain-overlay-bg: rgba(255, 255, 255, 0.84);
+  --brain-card-overlay: rgba(255, 255, 255, 0.7);
+  --brain-card-overlay-strong: rgba(255, 255, 255, 0.72);
+  --brain-card-overlay-soft: rgba(255, 255, 255, 0.68);
+  --brain-border: rgba(15, 23, 42, 0.1);
+  --brain-border-strong: rgba(15, 23, 42, 0.16);
+  --brain-text: #011848;
+  --brain-muted: rgba(1, 24, 72, 0.66);
+  --brain-soft: rgba(1, 24, 72, 0.48);
+  --brain-accent: #ef0001;
+  --brain-accent-soft: rgba(239, 0, 1, 0.12);
+  --brain-accent-strong: rgba(239, 0, 1, 0.22);
+  --brain-accent-border: rgba(239, 0, 1, 0.34);
+  --brain-accent-outline: rgba(239, 0, 1, 0.18);
+  --brain-list-hover-border: rgba(239, 0, 1, 0.22);
+  --brain-list-hover-bg: rgba(239, 0, 1, 0.08);
+  --brain-danger: #dc2626;
+  --brain-danger-border: rgba(220, 38, 38, 0.3);
+  --brain-danger-bg: rgba(220, 38, 38, 0.08);
+  --brain-danger-ring: rgba(220, 38, 38, 0.16);
+  --brain-dot-ring: rgba(15, 23, 42, 0.08);
+  --brain-pill-bg: rgba(15, 23, 42, 0.06);
+  --brain-type-company: #011848;
+  --brain-type-application: #2355c4;
+  --brain-type-module: #ef0001;
+  --brain-type-ticket: #b45309;
+  --brain-type-defect: #dc2626;
+  --brain-type-user: #5b6b87;
+  --brain-type-screen: #0284c7;
+  --brain-type-testrun: #5fae24;
+  --brain-type-release: #7c3aed;
+  --brain-type-integration: #be185d;
+  --brain-type-note: #334155;
+  --brain-memory-decision: #0f9f63;
+  --brain-memory-decision-bg: rgba(15, 159, 99, 0.12);
+  --brain-memory-rule: #b45309;
+  --brain-memory-rule-bg: rgba(180, 83, 9, 0.12);
+  --brain-memory-pattern: #2563eb;
+  --brain-memory-pattern-bg: rgba(37, 99, 235, 0.12);
+  --brain-memory-context: #7c3aed;
+  --brain-memory-context-bg: rgba(124, 58, 237, 0.12);
+  --brain-memory-exception: #dc2626;
+  --brain-memory-exception-bg: rgba(220, 38, 38, 0.12);
+  --brain-memory-technical-note: #111827;
+  --brain-memory-technical-note-bg: rgba(15, 23, 42, 0.1);
+  --brain-shadow: 0 24px 72px rgba(15, 23, 42, 0.14);
+  --brain-canvas-bg:
+    radial-gradient(circle at 16% 18%, rgba(1, 24, 72, 0.16), transparent 24%),
+    radial-gradient(circle at 84% 84%, rgba(239, 0, 1, 0.1), transparent 30%),
+    linear-gradient(180deg, #fbfcff 0%, #eef2fb 100%);
+  color: var(--brain-text);
   display: flex;
   flex-direction: column;
+  gap: 18px;
+  min-height: calc(100vh - 64px);
   height: calc(100vh - 64px);
-  gap: 0;
+  padding: 18px;
   overflow: hidden;
-  background: linear-gradient(135deg, var(--tc-surface) 0%, var(--tc-surface-2) 50%, var(--tc-surface-alt) 100%);
+  background:
+    radial-gradient(circle at top left, rgba(1, 24, 72, 0.1), transparent 26%),
+    radial-gradient(circle at right bottom, rgba(239, 0, 1, 0.08), transparent 30%),
+    linear-gradient(180deg, var(--brain-bg-alt) 0%, var(--brain-bg) 100%);
+  font-family: var(--font-geist-sans, "Segoe UI", system-ui, sans-serif);
+  color-scheme: light;
 }
 
-/* Dark mode */
 :global(.dark) .brainPage {
-  background: linear-gradient(135deg, #050a12 0%, #0a1220 50%, #0d1a2d 100%);
+  --brain-bg: #030816;
+  --brain-bg-alt: #071027;
+  --brain-panel-bg: rgba(7, 16, 39, 0.76);
+  --brain-panel-strong: rgba(7, 16, 39, 0.92);
+  --brain-panel-muted: rgba(7, 16, 39, 0.58);
+  --brain-overlay-bg: rgba(7, 16, 39, 0.84);
+  --brain-card-overlay: rgba(7, 16, 39, 0.7);
+  --brain-card-overlay-strong: rgba(7, 16, 39, 0.72);
+  --brain-card-overlay-soft: rgba(7, 16, 39, 0.68);
+  --brain-border: rgba(255, 255, 255, 0.08);
+  --brain-border-strong: rgba(255, 255, 255, 0.14);
+  --brain-text: #f6f8fb;
+  --brain-muted: rgba(246, 248, 251, 0.66);
+  --brain-soft: rgba(246, 248, 251, 0.44);
+  --brain-accent: #ff6b6b;
+  --brain-accent-soft: rgba(239, 0, 1, 0.18);
+  --brain-accent-strong: rgba(239, 0, 1, 0.3);
+  --brain-accent-border: rgba(255, 107, 107, 0.34);
+  --brain-accent-outline: rgba(255, 107, 107, 0.2);
+  --brain-list-hover-border: rgba(255, 107, 107, 0.28);
+  --brain-list-hover-bg: rgba(239, 0, 1, 0.12);
+  --brain-danger: #f87171;
+  --brain-danger-border: rgba(248, 113, 113, 0.3);
+  --brain-danger-bg: rgba(248, 113, 113, 0.1);
+  --brain-danger-ring: rgba(248, 113, 113, 0.16);
+  --brain-dot-ring: rgba(255, 255, 255, 0.08);
+  --brain-pill-bg: rgba(255, 255, 255, 0.06);
+  --brain-type-company: #dbe7ff;
+  --brain-type-application: #8bb8ff;
+  --brain-type-module: #ff8a8a;
+  --brain-type-ticket: #ffe58f;
+  --brain-type-defect: #ffb3b3;
+  --brain-type-user: #c7d2fe;
+  --brain-type-screen: #7dd3fc;
+  --brain-type-testrun: #7cd343;
+  --brain-type-release: #c4b5fd;
+  --brain-type-integration: #f9a8d4;
+  --brain-type-note: #cbd5e1;
+  --brain-memory-decision: #2ddb87;
+  --brain-memory-decision-bg: rgba(45, 219, 135, 0.14);
+  --brain-memory-rule: #fbbf24;
+  --brain-memory-rule-bg: rgba(251, 191, 36, 0.16);
+  --brain-memory-pattern: #93c5fd;
+  --brain-memory-pattern-bg: rgba(147, 197, 253, 0.16);
+  --brain-memory-context: #c4b5fd;
+  --brain-memory-context-bg: rgba(196, 181, 253, 0.16);
+  --brain-memory-exception: #f87171;
+  --brain-memory-exception-bg: rgba(248, 113, 113, 0.16);
+  --brain-memory-technical-note: #f8fafc;
+  --brain-memory-technical-note-bg: rgba(248, 250, 252, 0.12);
+  --brain-shadow: 0 30px 90px rgba(0, 0, 0, 0.34);
+  --brain-canvas-bg:
+    radial-gradient(circle at 20% 16%, rgba(31, 85, 191, 0.16), transparent 22%),
+    radial-gradient(circle at 82% 84%, rgba(239, 0, 1, 0.14), transparent 26%),
+    linear-gradient(180deg, #08101f 0%, #030816 100%);
+  color-scheme: dark;
+}
+
+.brainPage * {
+  box-sizing: border-box;
 }
 
 .topBar {
+  position: relative;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 12px;
-  padding: 16px 24px;
-  border-bottom: 1px solid var(--tc-border);
-  flex-shrink: 0;
-  background: linear-gradient(180deg, var(--tc-surface) 0%, transparent 100%);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  gap: 16px;
+  padding: 22px 24px 20px;
+  border: 1px solid var(--brain-border);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-panel-bg) 100%);
+  box-shadow: var(--brain-shadow);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
 }
 
-:global(.dark) .topBar {
-  border-bottom: 1px solid rgba(239, 0, 1, 0.15);
-  background: linear-gradient(180deg, rgba(239, 0, 1, 0.05) 0%, transparent 100%);
-}
-
-.title {
-  font-size: 1.35rem;
-  font-weight: 800;
-  color: var(--tc-text-primary);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  text-shadow: none;
+.topBar::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle, var(--brain-accent-soft) 0%, transparent 70%);
+  pointer-events: none;
 }
 
 .topBarMain {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 20px;
+  gap: 18px;
   flex-wrap: wrap;
 }
 
@@ -52,32 +173,223 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  min-width: 280px;
+  max-width: 620px;
+}
+
+.kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--brain-accent);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2vw, 2.35rem);
+  font-weight: 760;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--brain-text);
 }
 
 .subtitleMeta {
-  font-size: 0.82rem;
-  color: var(--tc-text-muted);
-}
-
-:global(.dark) .subtitleMeta {
-  color: rgba(255,255,255,0.58);
+  max-width: 62ch;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--brain-muted);
 }
 
 .controlCluster {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex: 1;
   gap: 10px;
   flex-wrap: wrap;
-  flex: 1;
 }
 
-.filterRow {
+.searchShell {
+  position: relative;
+  flex: 1 1 280px;
+  min-width: min(360px, 100%);
+  max-width: 420px;
+}
+
+.searchInput {
+  width: 100%;
+  min-height: 46px;
+  padding: 0 16px;
+  border: 1px solid var(--brain-border);
+  border-radius: 16px;
+  background: var(--brain-panel-muted);
+  color: var(--brain-text);
+  font-size: 0.96rem;
+  outline: none;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.searchInput::placeholder {
+  color: var(--brain-soft);
+}
+
+.searchInput:focus-visible {
+  border-color: var(--brain-accent);
+  box-shadow: 0 0 0 4px var(--brain-accent-soft);
+  background: var(--brain-panel-strong);
+}
+
+.searchResults {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--brain-border);
+  border-radius: 20px;
+  background: var(--brain-panel-strong);
+  box-shadow: var(--brain-shadow);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+}
+
+.searchState {
+  padding: 12px;
+  font-size: 0.9rem;
+  color: var(--brain-muted);
+}
+
+.searchItem {
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 14px;
+  border: 0;
+  border-radius: 14px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.searchItem:hover,
+.searchItem:focus-visible {
+  background: var(--brain-accent-soft);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.searchDot,
+.filterDot,
+.listButtonDot {
+  --dot-color: var(--brain-accent);
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--dot-color);
+  box-shadow: 0 0 0 6px var(--brain-dot-ring);
+}
+
+.searchDot[data-node-type="Company"],
+.filterDot[data-node-type="Company"],
+.listButtonDot[data-node-type="Company"] {
+  --dot-color: var(--brain-type-company);
+}
+
+.searchDot[data-node-type="Application"],
+.filterDot[data-node-type="Application"],
+.listButtonDot[data-node-type="Application"] {
+  --dot-color: var(--brain-type-application);
+}
+
+.searchDot[data-node-type="Module"],
+.filterDot[data-node-type="Module"],
+.listButtonDot[data-node-type="Module"] {
+  --dot-color: var(--brain-type-module);
+}
+
+.searchDot[data-node-type="Ticket"],
+.filterDot[data-node-type="Ticket"],
+.listButtonDot[data-node-type="Ticket"] {
+  --dot-color: var(--brain-type-ticket);
+}
+
+.searchDot[data-node-type="Defect"],
+.filterDot[data-node-type="Defect"],
+.listButtonDot[data-node-type="Defect"] {
+  --dot-color: var(--brain-type-defect);
+}
+
+.searchDot[data-node-type="User"],
+.filterDot[data-node-type="User"],
+.listButtonDot[data-node-type="User"] {
+  --dot-color: var(--brain-type-user);
+}
+
+.searchDot[data-node-type="Screen"],
+.filterDot[data-node-type="Screen"],
+.listButtonDot[data-node-type="Screen"] {
+  --dot-color: var(--brain-type-screen);
+}
+
+.searchDot[data-node-type="TestRun"],
+.filterDot[data-node-type="TestRun"],
+.listButtonDot[data-node-type="TestRun"] {
+  --dot-color: var(--brain-type-testrun);
+}
+
+.searchDot[data-node-type="Release"],
+.filterDot[data-node-type="Release"],
+.listButtonDot[data-node-type="Release"] {
+  --dot-color: var(--brain-type-release);
+}
+
+.searchDot[data-node-type="Integration"],
+.filterDot[data-node-type="Integration"],
+.listButtonDot[data-node-type="Integration"] {
+  --dot-color: var(--brain-type-integration);
+}
+
+.searchDot[data-node-type="Note"],
+.filterDot[data-node-type="Note"],
+.listButtonDot[data-node-type="Note"] {
+  --dot-color: var(--brain-type-note);
+}
+
+.searchMeta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 2px;
+}
+
+.searchLabel {
+  font-size: 0.95rem;
+  font-weight: 650;
+  color: var(--brain-text);
+}
+
+.searchType {
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--brain-muted);
 }
 
 .depthControl {
@@ -89,153 +401,232 @@
 .depthBadge {
   display: inline-flex;
   align-items: center;
-  min-height: 38px;
+  justify-content: center;
+  min-height: 42px;
   padding: 0 14px;
-  border-radius: 12px;
-  border: 1px solid var(--tc-border);
-  background: var(--tc-surface-hover);
-  color: var(--tc-text-primary);
+  border: 1px solid var(--brain-border);
+  border-radius: 14px;
+  background: var(--brain-panel-muted);
+  color: var(--brain-text);
   font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-weight: 800;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-:global(.dark) .depthBadge {
-  border-color: rgba(255,255,255,0.12);
-  background: rgba(255,255,255,0.06);
-  color: #ffffff;
-}
-
-:global(.dark) .title {
-  color: #ffffff;
-  text-shadow: 0 0 20px rgba(239, 0, 1, 0.5);
-}
-
-.pulseOrb {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--tc-accent) 0%, #c80001 100%);
-  box-shadow: 0 0 20px rgba(239, 0, 1, 0.6), 0 0 40px rgba(239, 0, 1, 0.3);
-  animation: pulse 2s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; transform: scale(1); box-shadow: 0 0 20px rgba(239, 0, 1, 0.6), 0 0 40px rgba(239, 0, 1, 0.3); }
-  50% { opacity: 0.8; transform: scale(1.2); box-shadow: 0 0 30px rgba(239, 0, 1, 0.8), 0 0 60px rgba(239, 0, 1, 0.5); }
-}
-
-.searchInput {
-  padding: 10px 16px;
-  border-radius: 12px;
-  border: 1px solid var(--tc-border);
-  background: var(--tc-input-bg);
-  color: var(--tc-text-primary);
-  font-size: 0.9rem;
-  width: min(420px, 100%);
-  min-width: 240px;
-  outline: none;
-  transition: all 0.3s ease;
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
-}
-
-:global(.dark) .searchInput {
-  border: 1px solid rgba(239, 0, 1, 0.2);
-  background: rgba(0, 20, 40, 0.6);
-  color: #ffffff;
-}
-
-.searchInput::placeholder {
-  color: var(--tc-text-muted);
-}
-
-:global(.dark) .searchInput::placeholder {
-  color: rgba(255,255,255,0.4);
-}
-
-.searchInput:focus {
-  border-color: var(--tc-accent);
-  box-shadow: 0 0 20px rgba(239, 0, 1, 0.2);
-  background: var(--tc-surface);
-}
-
-:global(.dark) .searchInput:focus {
-  box-shadow: 0 0 20px rgba(239, 0, 1, 0.3);
-  background: rgba(0, 30, 50, 0.8);
-}
-
-.filterBtn {
-  padding: 8px 16px;
-  border-radius: 10px;
-  border: 1px solid var(--tc-border);
-  background: var(--tc-surface-hover);
-  color: var(--tc-text-muted);
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.25s ease;
+.filterRow {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 2px;
 }
 
-:global(.dark) .filterBtn {
-  border: 1px solid rgba(255,255,255,0.15);
-  background: rgba(255,255,255,0.05);
-  color: rgba(255,255,255,0.7);
+.filterRow::-webkit-scrollbar {
+  height: 6px;
 }
 
-.filterBtn:hover {
-  background: var(--tc-surface-2);
-  color: var(--tc-text-primary);
+.filterRow::-webkit-scrollbar-thumb {
+  background: var(--brain-border-strong);
+  border-radius: 999px;
+}
+
+.filterBtn,
+.filterBtnActive,
+.panelCloseBtn,
+.hudButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 14px;
+  border-radius: 14px;
+  border: 1px solid var(--brain-border);
+  background: var(--brain-panel-muted);
+  color: var(--brain-text);
+  font-size: 0.84rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.filterBtn:hover,
+.filterBtn:focus-visible,
+.panelCloseBtn:hover,
+.panelCloseBtn:focus-visible,
+.hudButton:hover,
+.hudButton:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  border-color: var(--brain-border-strong);
+  background: var(--brain-panel-strong);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
+  outline: none;
 }
 
-:global(.dark) .filterBtn:hover {
-  background: rgba(255,255,255,0.12);
-  color: #ffffff;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+.filterBtn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .filterBtnActive {
-  padding: 8px 16px;
-  border-radius: 10px;
-  border: 1px solid var(--tc-accent);
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.25s ease;
+  border-color: var(--brain-accent-border);
+  background: linear-gradient(180deg, var(--brain-accent-soft) 0%, rgba(0, 0, 0, 0) 100%);
+  color: var(--brain-text);
+  box-shadow: inset 0 0 0 1px var(--brain-accent-outline);
+}
+
+.statsBar {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(220px, 1.3fr) repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.scoreCard,
+.statCard {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  justify-content: center;
   gap: 6px;
-  background: linear-gradient(135deg, rgba(239,0,1,0.15) 0%, rgba(239,0,1,0.08) 100%);
-  color: var(--tc-accent);
-  box-shadow: 0 0 15px rgba(239, 0, 1, 0.2);
+  min-height: 108px;
+  padding: 16px 18px;
+  border: 1px solid var(--brain-border);
+  border-radius: 22px;
+  background: var(--brain-panel-muted);
+}
+
+.scoreCard {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top right, var(--brain-accent-soft), transparent 42%),
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-panel-muted) 100%);
+}
+
+.scoreCard::after {
+  content: "";
+  position: absolute;
+  right: -18px;
+  bottom: -18px;
+  width: 120px;
+  height: 120px;
+  border-radius: 999px;
+  background: radial-gradient(circle, var(--brain-accent-soft) 0%, transparent 68%);
+  pointer-events: none;
+}
+
+.scoreLabel,
+.statLabel {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--brain-muted);
+}
+
+.scoreValue,
+.statValue {
+  font-size: clamp(1.65rem, 2vw, 2.3rem);
+  line-height: 1;
+  font-weight: 760;
+  letter-spacing: -0.05em;
+  color: var(--brain-text);
+}
+
+.scoreValue {
+  color: var(--brain-accent);
+}
+
+.scoreNote {
+  max-width: 22ch;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--brain-muted);
 }
 
 .mainArea {
   display: flex;
   flex: 1;
-  overflow: hidden;
-  position: relative;
+  align-items: stretch;
+  gap: 14px;
+  min-height: 0;
+}
+
+.explorerShell,
+.panelShell {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  min-height: 0;
+  flex-shrink: 0;
 }
 
 .graphContainer {
-  flex: 1;
   position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 520px;
+  border: 1px solid var(--brain-border);
+  border-radius: 32px;
   overflow: hidden;
+  background: var(--brain-canvas-bg);
+  box-shadow: var(--brain-shadow);
+}
+
+.graphContainer::before,
+.graphContainer::after {
+  content: "";
+  position: absolute;
+  inset: auto;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.graphContainer::before {
+  top: -80px;
+  right: -30px;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, var(--brain-accent-soft) 0%, transparent 70%);
+}
+
+.graphContainer::after {
+  left: -70px;
+  bottom: -90px;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle, rgba(1, 24, 72, 0.12) 0%, transparent 74%);
+}
+
+.graphCanvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.graphCanvas:active {
+  cursor: grabbing;
+}
+
+.graphCanvasHover {
+  cursor: pointer;
 }
 
 .graphHud {
   position: absolute;
-  left: 18px;
-  right: 18px;
-  top: 18px;
-  z-index: 3;
+  inset: 18px 18px auto 18px;
+  z-index: 2;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -245,520 +636,1723 @@
 
 .graphHudGroup {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  gap: 10px;
   flex-wrap: wrap;
   pointer-events: auto;
+}
+
+.hudPill,
+.hudButton {
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid var(--brain-border);
+  background: var(--brain-overlay-bg);
+  color: var(--brain-text);
+  font-size: 0.8rem;
+  font-weight: 650;
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
 }
 
 .hudPill {
   display: inline-flex;
   align-items: center;
-  min-height: 34px;
-  padding: 0 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(1, 24, 72, 0.12);
-  background: rgba(255,255,255,0.9);
-  color: var(--tc-text-primary);
-  font-size: 0.75rem;
-  font-weight: 700;
-  backdrop-filter: blur(14px);
-}
-
-:global(.dark) .hudPill {
-  border-color: rgba(239,0,1,0.14);
-  background: rgba(5, 10, 18, 0.82);
-  color: #ffffff;
-}
-
-.hudButton {
-  display: inline-flex;
-  align-items: center;
-  min-height: 34px;
-  padding: 0 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(1, 24, 72, 0.12);
-  background: rgba(255,255,255,0.96);
-  color: var(--tc-text-primary);
-  font-size: 0.75rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  backdrop-filter: blur(14px);
-}
-
-.hudButton:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 20px rgba(1, 24, 72, 0.12);
-}
-
-:global(.dark) .hudButton {
-  border-color: rgba(239,0,1,0.18);
-  background: rgba(5, 10, 18, 0.88);
-  color: #ffffff;
-}
-
-:global(.dark) .hudButton:hover {
-  box-shadow: 0 8px 20px rgba(0,0,0,0.35);
-}
-
-.graphCanvas {
-  width: 100%;
-  height: 100%;
-  display: block;
-  cursor: grab;
-  transition: cursor 0.15s;
-}
-
-.graphCanvas:active {
-  cursor: grabbing;
-}
-
-.graphCanvasHover {
-  cursor: pointer !important;
-}
-
-.sidePanel {
-  width: 420px;
-  flex-shrink: 0;
-  border-left: 1px solid var(--tc-border);
-  overflow-y: auto;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  background: linear-gradient(180deg, var(--tc-surface) 0%, var(--tc-surface-2) 100%);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  box-shadow: -16px 0 40px rgba(1, 24, 72, 0.08);
-}
-
-:global(.dark) .sidePanel {
-  border-left: 1px solid rgba(239, 0, 1, 0.15);
-  background: linear-gradient(180deg, rgba(0, 20, 40, 0.95) 0%, rgba(10, 18, 32, 0.98) 100%);
-}
-
-.sidePanelHidden {
-  display: none;
-}
-
-.panelHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.panelCloseBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 36px;
-  padding: 0 12px;
-  border-radius: 10px;
-  border: 1px solid var(--tc-border);
-  background: var(--tc-surface-hover);
-  color: var(--tc-text-primary);
-  font-size: 0.76rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.panelCloseBtn:hover {
-  border-color: rgba(239, 0, 1, 0.3);
-  color: var(--tc-accent);
-}
-
-:global(.dark) .panelCloseBtn {
-  border-color: rgba(255,255,255,0.1);
-  background: rgba(255,255,255,0.05);
-  color: #ffffff;
-}
-
-.panelTitle {
-  font-size: 1.1rem;
-  font-weight: 800;
-  color: var(--tc-text-primary);
-  margin: 0;
-}
-
-:global(.dark) .panelTitle {
-  color: #ffffff;
-  text-shadow: 0 0 10px rgba(239, 0, 1, 0.3);
-}
-
-.panelSubtitle {
-  font-size: 0.8rem;
-  color: var(--tc-text-muted);
-  margin: 4px 0 0 0;
-}
-
-:global(.dark) .panelSubtitle {
-  color: rgba(255,255,255,0.5);
-}
-
-.panelSection {
-  padding: 16px;
-  border-radius: 14px;
-  border: 1px solid var(--tc-border);
-  background: linear-gradient(135deg, var(--tc-surface-hover) 0%, var(--tc-surface-2) 100%);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-}
-
-:global(.dark) .panelSection {
-  border: 1px solid rgba(239, 0, 1, 0.12);
-  background: linear-gradient(135deg, rgba(239, 0, 1, 0.05) 0%, rgba(0, 0, 0, 0.2) 100%);
-}
-
-.panelSectionTitle {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--tc-accent);
-  margin: 0 0 12px 0;
-}
-
-.metadataItem {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 0;
-  font-size: 0.82rem;
-  border-bottom: 1px solid var(--tc-border);
-}
-
-:global(.dark) .metadataItem {
-  border-bottom: 1px solid rgba(255,255,255,0.05);
-}
-
-.metadataItem:last-child {
-  border-bottom: none;
-}
-
-.metadataKey {
-  color: var(--tc-text-muted);
-}
-
-:global(.dark) .metadataKey {
-  color: rgba(255,255,255,0.5);
-}
-
-.metadataValue {
-  color: var(--tc-text-primary);
-  font-weight: 600;
-}
-
-:global(.dark) .metadataValue {
-  color: #ffffff;
-}
-
-.neighborItem {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 0.85rem;
-  color: var(--tc-text-primary);
-  border: 1px solid transparent;
-}
-
-:global(.dark) .neighborItem {
-  color: #ffffff;
-}
-
-.neighborItem:hover {
-  background: var(--tc-accent-soft);
-  border-color: rgba(239, 0, 1, 0.3);
-  transform: translateX(4px);
-}
-
-:global(.dark) .neighborItem:hover {
-  background: rgba(239, 0, 1, 0.1);
-}
-
-.neighborDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  background: var(--dot-color, #607d8b);
-  box-shadow: 0 0 8px var(--dot-color, #607d8b);
-}
-
-.neighborEdgeType {
-  font-size: 0.68rem;
-  color: var(--tc-text-muted);
-  margin-left: auto;
-  background: var(--tc-surface-2);
-  padding: 2px 8px;
-  border-radius: 6px;
-}
-
-:global(.dark) .neighborEdgeType {
-  color: rgba(255,255,255,0.4);
-  background: rgba(255,255,255,0.08);
-}
-
-.memoryCard {
-  padding: 14px;
-  border-radius: 10px;
-  border: 1px solid var(--tc-border);
-  background: linear-gradient(135deg, var(--tc-surface-hover) 0%, var(--tc-surface-2) 100%);
-  margin-bottom: 10px;
-  transition: all 0.2s ease;
-}
-
-:global(.dark) .memoryCard {
-  border: 1px solid rgba(255,255,255,0.1);
-  background: linear-gradient(135deg, rgba(255,255,255,0.03) 0%, rgba(0,0,0,0.1) 100%);
-}
-
-.memoryCard:hover {
-  border-color: rgba(239, 0, 1, 0.3);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
-}
-
-:global(.dark) .memoryCard:hover {
-  box-shadow: 0 8px 20px rgba(0,0,0,0.3);
-}
-
-.memoryTitle {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--tc-text-primary);
-  margin: 0 0 6px 0;
-}
-
-:global(.dark) .memoryTitle {
-  color: #ffffff;
-}
-
-.memorySummary {
-  font-size: 0.78rem;
-  color: var(--tc-text-muted);
-  margin: 0;
-  line-height: 1.5;
-}
-
-:global(.dark) .memorySummary {
-  color: rgba(255,255,255,0.6);
-}
-
-.memoryBadge {
-  display: inline-block;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  padding: 4px 10px;
-  border-radius: 6px;
-  margin-top: 8px;
-}
-
-.statsBar {
-  display: flex;
-  gap: 12px;
-  padding: 0;
-  margin-left: 0;
-  align-items: center;
-  flex-shrink: 0;
-  flex-wrap: wrap;
-}
-
-.statItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 14px;
-  border-radius: 10px;
-  background: var(--tc-accent-soft);
-  border: 1px solid rgba(239, 0, 1, 0.15);
-}
-
-:global(.dark) .statItem {
-  background: rgba(239, 0, 1, 0.08);
-}
-
-.statValue {
-  font-size: 1.3rem;
-  font-weight: 800;
-  color: var(--tc-accent);
-  text-shadow: 0 0 15px rgba(239, 0, 1, 0.3);
-}
-
-:global(.dark) .statValue {
-  text-shadow: 0 0 15px rgba(239, 0, 1, 0.5);
-}
-
-.statLabel {
-  font-size: 0.65rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--tc-text-muted);
-}
-
-:global(.dark) .statLabel {
-  color: rgba(255,255,255,0.5);
 }
 
 .emptyState {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  gap: 16px;
-  color: var(--tc-text-muted);
-  font-size: 1rem;
+  gap: 10px;
+  padding: 32px;
   text-align: center;
-  padding: 40px;
-}
-
-:global(.dark) .emptyState {
-  color: rgba(255,255,255,0.5);
+  color: var(--brain-muted);
 }
 
 .emptyIcon {
-  font-size: 5rem;
-  opacity: 0.4;
-  filter: grayscale(0.5);
+  width: 64px;
+  height: 64px;
+  border-radius: 999px;
+  border: 1px solid var(--brain-border-strong);
+  background:
+    radial-gradient(circle at center, var(--brain-accent-soft) 0%, transparent 58%),
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-panel-muted) 100%);
+  box-shadow: inset 0 0 0 8px rgba(255, 255, 255, 0.02);
 }
 
 .emptyDescription {
-  font-size: 0.85rem;
-  opacity: 0.7;
-  max-width: 400px;
+  max-width: 34ch;
+  line-height: 1.55;
+}
+
+.graphLegend {
+  position: absolute;
+  left: 20px;
+  bottom: 20px;
+  z-index: 2;
+  display: grid;
+  gap: 8px;
+  min-width: 180px;
+  padding: 14px 16px;
+  border: 1px solid var(--brain-border);
+  border-radius: 18px;
+  background: var(--brain-overlay-bg);
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.18);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+}
+
+.legendTitle {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--brain-muted);
+}
+
+.legendRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.legendSwatchHub,
+.legendSwatchFocus,
+.legendSwatchMuted {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.legendSwatchHub {
+  background: var(--brain-type-application);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--brain-type-application) 20%, transparent);
+}
+
+.legendSwatchFocus {
+  background: var(--brain-accent);
+  box-shadow: 0 0 0 6px var(--brain-accent-soft);
+}
+
+.legendSwatchMuted {
+  background: color-mix(in srgb, var(--brain-type-note) 72%, white 28%);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--brain-type-note) 14%, transparent);
+}
+
+.legendLabel {
+  font-size: 0.84rem;
+  color: var(--brain-muted);
+}
+
+.sidePanel,
+.sidePanelHidden {
+  width: min(420px, 36vw);
+  min-width: 340px;
+  border: 1px solid var(--brain-border);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at top right, var(--brain-accent-soft) 0%, transparent 28%),
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-panel-bg) 100%);
+  box-shadow: var(--brain-shadow);
+  overflow: auto;
+  transition:
+    width 220ms ease,
+    min-width 220ms ease,
+    opacity 200ms ease,
+    transform 220ms ease,
+    padding 220ms ease,
+    border-color 220ms ease,
+    margin 220ms ease;
+}
+
+.sidePanel {
+  padding: 18px;
+}
+
+.sidePanelHidden {
+  width: 0;
+  min-width: 0;
+  padding: 0;
+  margin-left: -6px;
+  border-color: transparent;
+  opacity: 0;
+  overflow: hidden;
+  transform: translateX(20px);
+}
+
+.sidePanel::-webkit-scrollbar,
+.sidePanelHidden::-webkit-scrollbar {
+  width: 8px;
+}
+
+.sidePanel::-webkit-scrollbar-thumb,
+.sidePanelHidden::-webkit-scrollbar-thumb {
+  background: var(--brain-border-strong);
+  border-radius: 999px;
+}
+
+.panelHeader {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+  background:
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, rgba(255, 255, 255, 0) 100%);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+}
+
+:global(.dark) .panelHeader {
+  background:
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, rgba(11, 17, 23, 0) 100%);
+}
+
+.panelTitleWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.1;
+  font-weight: 730;
+  letter-spacing: -0.03em;
+  color: var(--brain-text);
+  word-break: break-word;
+}
+
+.panelSubtitle {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--brain-muted);
+  word-break: break-word;
+}
+
+.panelCloseBtn {
+  flex: 0 0 auto;
+}
+
+.sideRail {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.sideRailLeft,
+.sideRailRight {
+  align-self: stretch;
+}
+
+.sideRailButton {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 36px;
+  padding: 14px 8px;
+  border: 1px solid var(--brain-border);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-card-overlay-soft) 100%);
+  color: var(--brain-muted);
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease;
+}
+
+.sideRailButton:hover,
+.sideRailButton:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--brain-accent-border);
+  color: var(--brain-text);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  outline: none;
+}
+
+.sideRailArrow {
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.sideRailLabel {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.panelSection,
+.panelSectionHero {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--brain-border);
+  border-radius: 22px;
+  background: var(--brain-panel-muted);
+}
+
+.panelSection + .panelSection,
+.panelSectionHero + .panelSection,
+.panelSection + .panelSectionHero {
+  margin-top: 14px;
+}
+
+.panelSectionHero {
+  background:
+    radial-gradient(circle at top right, var(--brain-accent-soft) 0%, transparent 44%),
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-panel-muted) 100%);
+}
+
+.panelSectionTitle {
+  margin: 0;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--brain-muted);
+}
+
+.panelHeroValue {
+  font-size: clamp(2.6rem, 4vw, 3.7rem);
+  line-height: 0.95;
+  font-weight: 800;
+  letter-spacing: -0.08em;
+  color: var(--brain-accent);
+}
+
+.panelHeroMeta {
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--brain-muted);
+}
+
+.panelActionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.panelActionBtn,
+.panelActionBtnDanger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 12px;
+  border-radius: 12px;
+  border: 1px solid var(--brain-border);
+  background: var(--brain-card-overlay-strong);
+  color: var(--brain-text);
+  font-size: 0.8rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background-color 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.panelActionBtn:hover,
+.panelActionBtn:focus-visible,
+.panelActionBtnDanger:hover,
+.panelActionBtnDanger:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.1);
+  outline: none;
+}
+
+.panelActionBtn:hover,
+.panelActionBtn:focus-visible {
+  border-color: var(--brain-accent-border);
+  background: var(--brain-accent-soft);
+}
+
+.panelActionBtnDanger {
+  border-color: var(--brain-danger-border);
+  background: var(--brain-danger-bg);
+  color: var(--brain-danger);
+}
+
+.panelActionBtnDanger:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.inlineError {
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--brain-danger-border);
+  background: var(--brain-danger-bg);
+  color: var(--brain-danger);
+  font-size: 0.82rem;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.metricCell {
+  display: grid;
+  gap: 6px;
+  min-height: 84px;
+  padding: 12px 14px;
+  border: 1px solid var(--brain-border);
+  border-radius: 18px;
+  background: var(--brain-card-overlay);
+}
+
+.metricName {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--brain-soft);
+}
+
+.metricValue {
+  align-self: end;
+  font-size: 1.4rem;
+  line-height: 1;
+  font-weight: 740;
+  letter-spacing: -0.04em;
+  color: var(--brain-text);
+}
+
+.alertList,
+.nodeList,
+.metadataList {
+  display: grid;
+  gap: 10px;
+}
+
+.alertItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--brain-danger-border);
+  border-radius: 16px;
+  background: var(--brain-danger-bg);
+  color: var(--brain-text);
   line-height: 1.5;
 }
 
-.legend {
+.alertDot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  margin-top: 0.38rem;
+  border-radius: 999px;
+  background: var(--brain-danger);
+  box-shadow: 0 0 0 6px var(--brain-danger-ring);
+}
+
+.listButton {
   display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 14px;
+  border: 1px solid var(--brain-border);
+  border-radius: 18px;
+  background: var(--brain-card-overlay-strong);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.listButton:hover,
+.listButton:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--brain-list-hover-border);
+  background: var(--brain-list-hover-bg);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  outline: none;
+}
+
+.listButtonBody {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.listButtonTitle,
+.memoryTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 680;
+  line-height: 1.4;
+  color: var(--brain-text);
+  word-break: break-word;
+}
+
+.listButtonMeta,
+.metadataKey,
+.memorySummary {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--brain-muted);
+  word-break: break-word;
+}
+
+.metadataItem {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 16px;
-  padding: 14px 24px;
-  border-top: 1px solid var(--tc-border);
-  flex-shrink: 0;
-  flex-wrap: wrap;
-  background: linear-gradient(180deg, transparent 0%, var(--tc-surface-hover) 100%);
+  padding: 12px 14px;
+  border: 1px solid var(--brain-border);
+  border-radius: 16px;
+  background: var(--brain-card-overlay-soft);
 }
 
-:global(.dark) .legend {
-  border-top: 1px solid rgba(239, 0, 1, 0.12);
-  background: linear-gradient(180deg, transparent 0%, rgba(239, 0, 1, 0.03) 100%);
+.metadataValue {
+  justify-self: end;
+  max-width: 180px;
+  font-size: 0.9rem;
+  font-weight: 650;
+  text-align: right;
+  line-height: 1.45;
+  color: var(--brain-text);
+  word-break: break-word;
 }
 
-.legendItem {
-  display: flex;
-  align-items: center;
+.memoryCard {
+  display: grid;
   gap: 8px;
-  font-size: 0.75rem;
-  color: var(--tc-text-muted);
-  padding: 4px 10px;
-  border-radius: 6px;
-  transition: all 0.2s ease;
+  padding: 14px;
+  border: 1px solid var(--brain-border);
+  border-radius: 18px;
+  background: var(--brain-card-overlay-strong);
 }
 
-:global(.dark) .legendItem {
-  color: rgba(255,255,255,0.6);
-}
-
-.legendItem:hover {
-  background: var(--tc-surface-2);
-  color: var(--tc-text-primary);
-}
-
-:global(.dark) .legendItem:hover {
-  background: rgba(255,255,255,0.08);
-  color: #ffffff;
-}
-
-.legendDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--dot-color, #607d8b);
-  box-shadow: 0 0 6px var(--dot-color, #607d8b);
-}
-
-.filterDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--dot-color, #607d8b);
-  box-shadow: 0 0 6px var(--dot-color, #607d8b);
-  display: inline-block;
-  margin-right: 4px;
-  vertical-align: middle;
-}
-
-.pulseOrbLg {
-  display: inline-block;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--tc-accent) 0%, #c80001 100%);
-  box-shadow: 0 0 20px rgba(239, 0, 1, 0.6), 0 0 40px rgba(239, 0, 1, 0.3);
-  animation: pulse 2s ease-in-out infinite;
-  width: 32px;
-  height: 32px;
-}
-
-.legendHint {
-  display: flex;
+.memoryBadgeDynamic,
+.pill,
+.pillMuted {
+  --badge-bg: rgba(255, 255, 255, 0.08);
+  --badge-color: var(--brain-text);
+  --pill-color: var(--brain-accent);
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 0.7rem;
-  color: var(--tc-text-muted);
-  padding: 4px 10px;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  margin-left: auto;
-  opacity: 0.5;
-  background: var(--tc-accent-soft);
-  border: 1px solid rgba(239, 0, 1, 0.1);
-}
-
-@media (max-width: 1280px) {
-  .sidePanel {
-    width: 360px;
-  }
-}
-
-@media (max-width: 980px) {
-  .graphHud {
-    left: 12px;
-    right: 12px;
-    top: 12px;
-    flex-direction: column;
-  }
-
-  .topBar {
-    padding: 14px 16px;
-  }
-
-  .searchInput {
-    width: 100%;
-  }
-}
-
-:global(.dark) .legendHint {
-  color: rgba(255,255,255,0.6);
-  background: rgba(239, 0, 1, 0.05);
+  justify-content: center;
+  width: fit-content;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .memoryBadgeDynamic {
-  display: inline-block;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
+  background: var(--badge-bg);
+  color: var(--badge-color);
+}
+
+.memoryBadgeDynamic[data-memory-type="DECISION"] {
+  --badge-bg: var(--brain-memory-decision-bg);
+  --badge-color: var(--brain-memory-decision);
+}
+
+.memoryBadgeDynamic[data-memory-type="RULE"] {
+  --badge-bg: var(--brain-memory-rule-bg);
+  --badge-color: var(--brain-memory-rule);
+}
+
+.memoryBadgeDynamic[data-memory-type="PATTERN"] {
+  --badge-bg: var(--brain-memory-pattern-bg);
+  --badge-color: var(--brain-memory-pattern);
+}
+
+.memoryBadgeDynamic[data-memory-type="CONTEXT"] {
+  --badge-bg: var(--brain-memory-context-bg);
+  --badge-color: var(--brain-memory-context);
+}
+
+.memoryBadgeDynamic[data-memory-type="EXCEPTION"] {
+  --badge-bg: var(--brain-memory-exception-bg);
+  --badge-color: var(--brain-memory-exception);
+}
+
+.memoryBadgeDynamic[data-memory-type="TECHNICAL_NOTE"] {
+  --badge-bg: var(--brain-memory-technical-note-bg);
+  --badge-color: var(--brain-memory-technical-note);
+}
+
+.pillRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  background: var(--brain-pill-bg);
+  color: var(--pill-color);
+  box-shadow: inset 0 0 0 1px var(--pill-color);
+}
+
+.pill[data-node-type="Company"] {
+  --pill-color: var(--brain-type-company);
+}
+
+.pill[data-node-type="Application"] {
+  --pill-color: var(--brain-type-application);
+}
+
+.pill[data-node-type="Module"] {
+  --pill-color: var(--brain-type-module);
+}
+
+.pill[data-node-type="Ticket"] {
+  --pill-color: var(--brain-type-ticket);
+}
+
+.pill[data-node-type="Defect"] {
+  --pill-color: var(--brain-type-defect);
+}
+
+.pill[data-node-type="User"] {
+  --pill-color: var(--brain-type-user);
+}
+
+.pill[data-node-type="Screen"] {
+  --pill-color: var(--brain-type-screen);
+}
+
+.pill[data-node-type="TestRun"] {
+  --pill-color: var(--brain-type-testrun);
+}
+
+.pill[data-node-type="Release"] {
+  --pill-color: var(--brain-type-release);
+}
+
+.pill[data-node-type="Integration"] {
+  --pill-color: var(--brain-type-integration);
+}
+
+.pill[data-node-type="Note"] {
+  --pill-color: var(--brain-type-note);
+}
+
+.pillMuted {
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-muted);
+  box-shadow: inset 0 0 0 1px var(--brain-border);
+}
+
+/* Legend type swatch */
+.legendSwatchType {
+  --swatch-color: var(--brain-text);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--swatch-color);
+  flex-shrink: 0;
+  box-shadow: 0 0 6px var(--swatch-color);
+}
+
+/* Type accent injection via data-type attribute
+   Replaces inline CSS custom properties for --dot-color, --swatch-color, --pill-color.
+   Works for: .listButtonDot, .filterDot, .explorerGroupDot, .searchDot,
+              .legendSwatchType, .createPreviewDot, .paletteItemDot,
+              .filterBtnActive, .pill */
+.brainPage [data-type="Company"]     { --dot-color: var(--brain-type-company);     --swatch-color: var(--brain-type-company);     --pill-color: var(--brain-type-company); }
+.brainPage [data-type="Application"] { --dot-color: var(--brain-type-application); --swatch-color: var(--brain-type-application); --pill-color: var(--brain-type-application); }
+.brainPage [data-type="Module"]      { --dot-color: var(--brain-type-module);      --swatch-color: var(--brain-type-module);      --pill-color: var(--brain-type-module); }
+.brainPage [data-type="Ticket"]      { --dot-color: var(--brain-type-ticket);      --swatch-color: var(--brain-type-ticket);      --pill-color: var(--brain-type-ticket); }
+.brainPage [data-type="Defect"]      { --dot-color: var(--brain-type-defect);      --swatch-color: var(--brain-type-defect);      --pill-color: var(--brain-type-defect); }
+.brainPage [data-type="User"]        { --dot-color: var(--brain-type-user);        --swatch-color: var(--brain-type-user);        --pill-color: var(--brain-type-user); }
+.brainPage [data-type="Screen"]      { --dot-color: var(--brain-type-screen);      --swatch-color: var(--brain-type-screen);      --pill-color: var(--brain-type-screen); }
+.brainPage [data-type="TestRun"]     { --dot-color: var(--brain-type-testrun);     --swatch-color: var(--brain-type-testrun);     --pill-color: var(--brain-type-testrun); }
+.brainPage [data-type="Release"]     { --dot-color: var(--brain-type-release);     --swatch-color: var(--brain-type-release);     --pill-color: var(--brain-type-release); }
+.brainPage [data-type="Integration"] { --dot-color: var(--brain-type-integration); --swatch-color: var(--brain-type-integration); --pill-color: var(--brain-type-integration); }
+.brainPage [data-type="Note"]        { --dot-color: var(--brain-type-note);        --swatch-color: var(--brain-type-note);        --pill-color: var(--brain-type-note); }
+
+.legendSeparator {
+  height: 1px;
+  background: var(--brain-border);
+  margin: 4px 0;
+}
+
+.legendShortcuts {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.7rem;
+  color: var(--brain-soft);
+  letter-spacing: 0.02em;
+}
+
+/* Panel tabs */
+.panelTabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 20px 12px;
+  border-bottom: 1px solid var(--brain-border);
+  flex-shrink: 0;
+}
+
+.panelTab,
+.panelTabActive {
+  padding: 7px 14px;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  font-weight: 660;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease;
+  white-space: nowrap;
+}
+
+.panelTab {
+  background: transparent;
+  color: var(--brain-muted);
+  border-color: transparent;
+}
+
+.panelTab:hover {
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-text);
+}
+
+.panelTabActive {
+  background: var(--brain-accent-soft);
+  color: var(--brain-accent);
+  border-color: var(--brain-accent-border);
+}
+
+/* Chat panel */
+.chatPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.chatContext {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 20px 8px;
+  flex-shrink: 0;
+}
+
+.chatContextBadge {
+  font-size: 0.78rem;
+  font-weight: 620;
+  color: var(--brain-muted);
+  background: var(--brain-card-overlay-soft);
+  border: 1px solid var(--brain-border);
   padding: 4px 10px;
-  border-radius: 6px;
+  border-radius: 999px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+.chatClearBtn {
+  font-size: 0.76rem;
+  font-weight: 660;
+  color: var(--brain-soft);
+  background: transparent;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 140ms ease;
+}
+
+.chatClearBtn:hover {
+  color: var(--brain-danger);
+}
+
+.chatMessages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 20px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.chatMessages::-webkit-scrollbar { width: 4px; }
+.chatMessages::-webkit-scrollbar-thumb { background: var(--brain-border); border-radius: 4px; }
+.chatMessages::-webkit-scrollbar-track { background: transparent; }
+
+.chatEmpty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px 8px;
+  text-align: center;
+}
+
+.chatEmptyTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--brain-text);
+}
+
+.chatEmptyMeta {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--brain-muted);
+  max-width: 260px;
+  line-height: 1.5;
+}
+
+.chatSuggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
   margin-top: 8px;
-  background: var(--badge-bg, rgba(96,125,139,0.12));
-  color: var(--badge-color, #607d8b);
+}
+
+.chatSuggestionBtn {
+  width: 100%;
+  padding: 9px 14px;
+  border: 1px solid var(--brain-border);
+  border-radius: 14px;
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-muted);
+  font-size: 0.82rem;
+  font-weight: 560;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    color 140ms ease;
+}
+
+.chatSuggestionBtn:hover {
+  border-color: var(--brain-accent-border);
+  background: var(--brain-accent-soft);
+  color: var(--brain-text);
+}
+
+.chatMsgUser,
+.chatMsgAssistant {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--brain-border);
+}
+
+.chatMsgUser {
+  background: var(--brain-accent-soft);
+  border-color: var(--brain-accent-outline);
+  align-self: flex-end;
+  max-width: 92%;
+}
+
+.chatMsgAssistant {
+  background: var(--brain-card-overlay-strong);
+  align-self: flex-start;
+  max-width: 100%;
+}
+
+.chatMsgRole {
+  font-size: 0.72rem;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--brain-soft);
+}
+
+.chatMsgUser .chatMsgRole {
+  color: var(--brain-accent);
+}
+
+.chatMsgContent {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: var(--brain-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chatLoading {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 14px;
+  align-self: flex-start;
+}
+
+.chatLoadingDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brain-accent);
+  animation: chatDotPulse 1.2s ease-in-out infinite;
+}
+
+.chatLoadingDot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.chatLoadingDot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes chatDotPulse {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+.chatForm {
+  display: flex;
+  gap: 8px;
+  padding: 12px 20px 16px;
+  flex-shrink: 0;
+  border-top: 1px solid var(--brain-border);
+}
+
+.chatInput {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 14px;
+  border: 1px solid var(--brain-border);
+  border-radius: 14px;
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 140ms ease;
+}
+
+.chatInput:focus {
+  border-color: var(--brain-accent-border);
+}
+
+.chatInput::placeholder {
+  color: var(--brain-soft);
+}
+
+.chatInput:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.chatSendBtn {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 14px;
+  background: var(--brain-accent);
+  color: #fff;
+  font-size: 0.86rem;
+  font-weight: 700;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    opacity 140ms ease,
+    transform 100ms ease;
+}
+
+.chatSendBtn:hover:not(:disabled) {
+  opacity: 0.88;
+  transform: translateY(-1px);
+}
+
+.chatSendBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Create node panel */
+.createPanel {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.createPanel::-webkit-scrollbar { width: 4px; }
+.createPanel::-webkit-scrollbar-thumb { background: var(--brain-border); border-radius: 4px; }
+.createPanel::-webkit-scrollbar-track { background: transparent; }
+
+.createForm {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.createHint {
+  margin: 0 0 4px;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--brain-muted);
+}
+
+.createLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.82rem;
+  font-weight: 660;
+  color: var(--brain-muted);
+}
+
+.createInput,
+.createSelect,
+.createTextarea {
+  padding: 10px 13px;
+  border: 1px solid var(--brain-border);
+  border-radius: 12px;
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 140ms ease;
+}
+
+.createInput:focus,
+.createSelect:focus,
+.createTextarea:focus {
+  border-color: var(--brain-accent-border);
+}
+
+.createSelect {
+  cursor: pointer;
+  appearance: auto;
+}
+
+.createTextarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.createToggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 13px;
+  border: 1px solid var(--brain-border);
+  border-radius: 14px;
+  background: var(--brain-card-overlay-soft);
+  cursor: pointer;
+}
+
+.createToggle input {
+  margin-top: 2px;
+  accent-color: var(--brain-accent);
+}
+
+.createToggleText {
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--brain-text);
+}
+
+.createError {
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--brain-danger-bg);
+  border: 1px solid var(--brain-danger-border);
+  color: var(--brain-danger);
+  font-size: 0.84rem;
+}
+
+.createPreview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 13px;
+  border: 1px solid var(--brain-border);
+  border-radius: 12px;
+  background: var(--brain-card-overlay);
+  font-size: 0.9rem;
+  font-weight: 580;
+  color: var(--brain-text);
+}
+
+.createPreviewDot {
+  --dot-color: var(--brain-accent);
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--dot-color);
+  flex-shrink: 0;
+  box-shadow: 0 0 8px var(--dot-color);
+}
+
+.createPreviewType {
+  margin-left: auto;
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: var(--brain-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.createSubmitBtn {
+  padding: 12px 18px;
+  border: none;
+  border-radius: 14px;
+  background: var(--brain-accent);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    opacity 140ms ease,
+    transform 100ms ease;
+}
+
+.createSubmitBtn:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.createSubmitBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Workspace bar */
+.workspaceBar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.workspaceBtn,
+.workspaceBtnActive {
+  padding: 5px 12px;
+  border-radius: 10px;
+  font-size: 0.78rem;
+  font-weight: 660;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 130ms ease, color 130ms ease, border-color 130ms ease;
+  white-space: nowrap;
+}
+
+.workspaceBtn {
+  background: transparent;
+  color: var(--brain-muted);
+}
+
+.workspaceBtn:hover {
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-text);
+}
+
+.workspaceBtnActive {
+  background: var(--brain-accent-soft);
+  color: var(--brain-accent);
+  border-color: var(--brain-accent-border);
+}
+
+.workspaceSep {
+  width: 1px;
+  height: 16px;
+  background: var(--brain-border);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Left Explorer Panel */
+.explorerPanel {
+  width: 240px;
+  min-width: 220px;
+  max-width: 260px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 28px;
+  border: 1px solid var(--brain-border);
+  background:
+    linear-gradient(180deg, var(--brain-panel-strong) 0%, var(--brain-panel-bg) 100%);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+}
+
+.explorerHeader {
+  display: grid;
+  gap: 4px;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--brain-border);
+  flex-shrink: 0;
+}
+
+.explorerHeading {
+  display: grid;
+  gap: 4px;
+}
+
+.explorerTitle {
+  font-size: 0.82rem;
+  font-weight: 760;
+  color: var(--brain-text);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.explorerCount {
+  font-size: 0.74rem;
+  color: var(--brain-soft);
+  font-weight: 580;
+}
+
+.explorerBody {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 0 12px;
+}
+
+.explorerBody::-webkit-scrollbar { width: 4px; }
+.explorerBody::-webkit-scrollbar-thumb { background: var(--brain-border); border-radius: 4px; }
+.explorerBody::-webkit-scrollbar-track { background: transparent; }
+
+.explorerGroup {
+  margin-bottom: 2px;
+}
+
+.explorerGroupHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--brain-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  transition: color 130ms ease, background 130ms ease;
+  text-align: left;
+}
+
+.explorerGroupHeader:hover {
+  color: var(--brain-text);
+  background: var(--brain-card-overlay-soft);
+}
+
+.explorerGroupDot {
+  --dot-color: var(--brain-accent);
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--dot-color);
+  flex-shrink: 0;
+}
+
+.explorerGroupLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.explorerGroupCount {
+  font-size: 0.72rem;
+  color: var(--brain-soft);
+  background: var(--brain-card-overlay);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.explorerGroupChevron {
+  font-size: 0.72rem;
+  color: var(--brain-soft);
+  flex-shrink: 0;
+}
+
+.explorerItems {
+  padding: 2px 0 4px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.explorerItem,
+.explorerItemActive {
+  width: 100%;
+  padding: 4px 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--brain-muted);
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-align: left;
+  border-radius: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.explorerItem:hover {
+  background: var(--brain-card-overlay-soft);
+  color: var(--brain-text);
+}
+
+.explorerItemActive {
+  background: var(--brain-accent-soft);
+  color: var(--brain-accent);
+  font-weight: 660;
+}
+
+/* Tab badge */
+.tabBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--brain-accent);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 800;
+  margin-left: 4px;
+}
+
+/* Timeline */
+.timelinePanel {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.timelinePanel::-webkit-scrollbar { width: 4px; }
+.timelinePanel::-webkit-scrollbar-thumb { background: var(--brain-border); border-radius: 4px; }
+.timelinePanel::-webkit-scrollbar-track { background: transparent; }
+
+.timelineList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 4px 0;
+}
+
+.timelineItem {
+  display: flex;
+  gap: 12px;
+  padding: 0 0 16px;
+}
+
+.timelineDotWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 14px;
+  margin-top: 4px;
+}
+
+.timelineDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--brain-accent);
+  border: 2px solid var(--brain-panel-bg);
+  box-shadow: 0 0 0 2px var(--brain-accent-border);
+  flex-shrink: 0;
+}
+
+.timelineLine {
+  flex: 1;
+  width: 2px;
+  background: var(--brain-border);
+  margin-top: 4px;
+}
+
+.timelineItem:last-child .timelineLine {
+  display: none;
+}
+
+.timelineContent {
+  flex: 1;
+  min-width: 0;
+  padding-bottom: 4px;
+}
+
+.timelineAction {
+  margin: 0 0 2px;
+  font-size: 0.86rem;
+  font-weight: 680;
+  color: var(--brain-text);
+  line-height: 1.3;
+}
+
+.timelineReason {
+  margin: 0 0 4px;
+  font-size: 0.8rem;
+  color: var(--brain-muted);
+  line-height: 1.4;
+}
+
+.timelineDate {
+  font-size: 0.72rem;
+  color: var(--brain-soft);
+  font-weight: 580;
+}
+
+/* Command Palette */
+.paletteOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: rgba(0, 0, 0, 0.48);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: clamp(60px, 12vh, 140px);
+}
+
+.paletteModal {
+  width: min(620px, calc(100vw - 32px));
+  border-radius: 22px;
+  border: 1px solid var(--brain-border-strong);
+  background: var(--brain-panel-strong);
+  -webkit-backdrop-filter: blur(32px);
+  backdrop-filter: blur(32px);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.paletteInput {
+  width: 100%;
+  padding: 18px 22px;
+  border: none;
+  border-bottom: 1px solid var(--brain-border);
+  background: transparent;
+  color: var(--brain-text);
+  font-size: 1.05rem;
+  font-family: inherit;
+  font-weight: 500;
+  outline: none;
+}
+
+.paletteInput::placeholder {
+  color: var(--brain-soft);
+}
+
+.paletteResults {
+  max-height: min(440px, 60vh);
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.paletteResults::-webkit-scrollbar { width: 4px; }
+.paletteResults::-webkit-scrollbar-thumb { background: var(--brain-border); border-radius: 4px; }
+.paletteResults::-webkit-scrollbar-track { background: transparent; }
+
+.paletteSection {
+  padding: 4px 0;
+}
+
+.paletteSectionTitle {
+  display: block;
+  padding: 4px 18px 2px;
+  font-size: 0.7rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--brain-soft);
+}
+
+.paletteItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 18px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--brain-text);
+  text-align: left;
+  transition: background 100ms ease;
+}
+
+.paletteItem:hover,
+.paletteItemActive {
+  background: var(--brain-accent-soft);
+}
+
+.paletteItemIcon {
+  font-size: 0.9rem;
+  color: var(--brain-soft);
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+}
+
+.paletteItemDot {
+  --dot-color: var(--brain-accent);
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--dot-color);
+  flex-shrink: 0;
+  box-shadow: 0 0 6px var(--dot-color);
+}
+
+.paletteItemLabel {
+  flex: 1;
+  font-size: 0.92rem;
+  font-weight: 560;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.paletteItemMeta {
+  font-size: 0.76rem;
+  color: var(--brain-soft);
+  flex-shrink: 0;
+}
+
+.paletteItemShortcut {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--brain-soft);
+  background: var(--brain-card-overlay);
+  border: 1px solid var(--brain-border);
+  padding: 2px 6px;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.paletteEmpty {
+  padding: 16px 18px;
+  color: var(--brain-soft);
+  font-size: 0.88rem;
+  text-align: center;
+}
+
+.paletteFooter {
+  display: flex;
+  gap: 14px;
+  padding: 10px 18px;
+  border-top: 1px solid var(--brain-border);
+  font-size: 0.72rem;
+  color: var(--brain-soft);
+}
+
+@media (max-width: 1260px) {
+  .statsBar {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .scoreCard {
+    grid-column: span 3;
+  }
+
+  .sidePanel,
+  .sidePanelHidden {
+    width: min(380px, 38vw);
+  }
+}
+
+@media (max-width: 1080px) {
+  .mainArea {
+    flex-direction: column;
+  }
+
+  .explorerShell,
+  .panelShell {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .sideRail {
+    width: 100%;
+  }
+
+  .sideRailButton {
+    width: 100%;
+    min-height: 42px;
+    flex-direction: row;
+  }
+
+  .sideRailLabel {
+    writing-mode: initial;
+    transform: none;
+  }
+
+  .explorerPanel {
+    width: 100%;
+    max-width: none;
+    max-height: 220px;
+  }
+
+  .graphContainer {
+    min-height: 500px;
+  }
+
+  .sidePanel,
+  .sidePanelHidden {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .sidePanelHidden {
+    display: none;
+  }
+}
+
+@media (max-width: 840px) {
+  .brainPage {
+    padding: 14px;
+    gap: 14px;
+  }
+
+  .topBar {
+    padding: 18px;
+    border-radius: 24px;
+  }
+
+  .statsBar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .scoreCard {
+    grid-column: span 2;
+  }
+
+  .graphHud {
+    inset: 14px 14px auto 14px;
+    flex-direction: column;
+  }
+
+  .graphLegend {
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .brainPage {
+    height: auto;
+    min-height: calc(100vh - 64px);
+  }
+
+  .title {
+    font-size: 1.7rem;
+  }
+
+  .searchShell {
+    min-width: 100%;
+    max-width: none;
+  }
+
+  .controlCluster {
+    justify-content: stretch;
+  }
+
+  .controlCluster > * {
+    width: 100%;
+  }
+
+  .depthControl {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .filterBtn,
+  .filterBtnActive,
+  .panelCloseBtn,
+  .panelActionBtn,
+  .panelActionBtnDanger {
+    width: 100%;
+  }
+
+  .statsBar,
+  .metricGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .scoreCard {
+    grid-column: auto;
+  }
+
+  .graphContainer {
+    min-height: 420px;
+    border-radius: 24px;
+  }
+
+  .panelHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .metadataItem {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .metadataValue {
+    justify-self: start;
+    text-align: left;
+  }
 }

--- a/app/admin/brain/BrainGraphView.tsx
+++ b/app/admin/brain/BrainGraphView.tsx
@@ -1,12 +1,216 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useBrainGraph, useBrainStats, useBrainNodeContext, useBrainMemories } from "@/hooks/useBrain";
-import type { BrainNode, BrainEdge, BrainMemory } from "@/hooks/useBrain";
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
+import {
+  useBrainGraph,
+  useBrainNodeContext,
+  useBrainSearch,
+  useBrainStats,
+  useBrainTimeline,
+} from "@/hooks/useBrain";
+import type {
+  BrainEdge,
+  BrainMemory,
+  BrainNode,
+  BrainNodeSuggestion,
+  BrainTimelineEntry,
+} from "@/hooks/useBrain";
 import { useTranslation } from "@/context/LanguageContext";
 import styles from "./Brain.module.css";
 
-/* â”€â”€â”€ Hook to detect theme â”€â”€â”€ */
+type SimNode = BrainNode & {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  fx?: number | null;
+  fy?: number | null;
+  degree: number;
+  layer: number;
+  orbitRadius: number;
+  anchorX: number;
+  anchorY: number;
+  mass: number;
+};
+
+const MAX_GRAPH_DEPTH = 4;
+
+const TYPE_RING_WEIGHTS: Record<string, number> = {
+  Company: 0.08,
+  Application: 0.24,
+  Module: 0.48,
+  User: 0.36,
+  Screen: 0.66,
+  Release: 0.6,
+  Integration: 0.78,
+  TestRun: 0.82,
+  Ticket: 1,
+  Defect: 1.06,
+  Note: 0.72,
+};
+
+const TYPE_ORBIT_PHASE: Record<string, number> = {
+  Company: 0.08,
+  Application: 0.14,
+  Module: 0.22,
+  User: 0.32,
+  Screen: 0.44,
+  Release: 0.52,
+  Integration: 0.62,
+  TestRun: 0.72,
+  Ticket: 0.82,
+  Defect: 0.9,
+  Note: 0.98,
+};
+
+const EMPTY_NODES: BrainNode[] = [];
+const EMPTY_EDGES: BrainEdge[] = [];
+const EMPTY_MEMORIES: BrainMemory[] = [];
+const EMPTY_SUGGESTIONS: BrainNodeSuggestion[] = [];
+const EMPTY_CONTEXT_EDGES: Array<{
+  id: string;
+  fromId: string;
+  toId: string;
+  type: string;
+}> = [];
+const EMPTY_IMPACT_PATHS: Array<{ nodeId: string; edgeType: string; distance: number }> = [];
+
+const GRAPH_PALETTES = {
+  dark: {
+    bgOuter: "#010715",
+    bgInner: "#071328",
+    bgGlow: "#143067",
+    nodeBase: "#c7d2e8",
+    nodeMuted: "#6c7fa4",
+    nodeHub: "#5b92ff",
+    nodeFocus: "#ef0001",
+    nodeSignal: "#ff7c7d",
+    edgeMuted: "rgba(91, 146, 255, 0.18)",
+    edgeHub: "rgba(91, 146, 255, 0.34)",
+    edgeActive: "rgba(239, 0, 1, 0.36)",
+    edgeFocus: "rgba(248, 250, 252, 0.56)",
+    edgeGlowHub: "rgba(91, 146, 255, 0.18)",
+    edgeGlowActive: "rgba(239, 0, 1, 0.18)",
+    edgeGlowFocus: "rgba(248, 250, 252, 0.18)",
+    label: "rgba(248, 250, 252, 0.95)",
+    labelMuted: "rgba(216, 225, 238, 0.7)",
+    labelShadow: "rgba(2, 8, 18, 0.96)",
+    haloHub: "rgba(91, 146, 255, 0.24)",
+    haloFocus: "rgba(239, 0, 1, 0.2)",
+    arrow: "rgba(91, 146, 255, 0.4)",
+    arrowHub: "rgba(91, 146, 255, 0.56)",
+    arrowFocus: "rgba(248, 250, 252, 0.72)",
+    arrowActive: "rgba(255, 124, 125, 0.76)",
+    edgeLabel: "rgba(220, 230, 242, 0.82)",
+  },
+  light: {
+    bgOuter: "#e9eef8",
+    bgInner: "#ffffff",
+    bgGlow: "#d7e4ff",
+    nodeBase: "#31425f",
+    nodeMuted: "#7a8ca8",
+    nodeHub: "#011848",
+    nodeFocus: "#ef0001",
+    nodeSignal: "#ff6d6f",
+    edgeMuted: "rgba(1, 24, 72, 0.12)",
+    edgeHub: "rgba(1, 24, 72, 0.26)",
+    edgeActive: "rgba(239, 0, 1, 0.24)",
+    edgeFocus: "rgba(15, 23, 42, 0.42)",
+    edgeGlowHub: "rgba(1, 24, 72, 0.1)",
+    edgeGlowActive: "rgba(239, 0, 1, 0.12)",
+    edgeGlowFocus: "rgba(15, 23, 42, 0.12)",
+    label: "rgba(15, 23, 42, 0.95)",
+    labelMuted: "rgba(51, 65, 85, 0.70)",
+    labelShadow: "rgba(255, 255, 255, 0.96)",
+    haloHub: "rgba(1, 24, 72, 0.14)",
+    haloFocus: "rgba(239, 0, 1, 0.14)",
+    arrow: "rgba(1, 24, 72, 0.28)",
+    arrowHub: "rgba(1, 24, 72, 0.42)",
+    arrowFocus: "rgba(15, 23, 42, 0.72)",
+    arrowActive: "rgba(239, 0, 1, 0.66)",
+    edgeLabel: "rgba(60, 80, 100, 0.80)",
+  },
+} as const;
+
+const TYPE_ACCENTS_DARK: Record<string, string> = {
+  Company: "#dbe7ff",
+  Application: "#8bb8ff",
+  Module: "#ff8a8a",
+  Ticket: "#fbbf24",
+  Defect: "#f87171",
+  User: "#c7d2fe",
+  Screen: "#22d3ee",
+  TestRun: "#7cd343",
+  Release: "#c084fc",
+  Integration: "#f472b6",
+  Note: "#94a3b8",
+};
+
+const TYPE_ACCENTS_LIGHT: Record<string, string> = {
+  Company: "#011848",
+  Application: "#2355c4",
+  Module: "#ef0001",
+  Ticket: "#b45309",
+  Defect: "#dc2626",
+  User: "#5b6b87",
+  Screen: "#0891b2",
+  TestRun: "#5fae24",
+  Release: "#9333ea",
+  Integration: "#db2777",
+  Note: "#475569",
+};
+
+const NODE_TYPES = [
+  "Company",
+  "Application",
+  "Module",
+  "Ticket",
+  "Defect",
+  "User",
+  "Screen",
+  "TestRun",
+  "Release",
+  "Integration",
+  "Note",
+];
+
+const CREATE_EDGE_TYPES = [
+  { value: "RELATES_TO", labelPt: "Relaciona com", labelEn: "Relates to" },
+  { value: "DEPENDS_ON", labelPt: "Depende de", labelEn: "Depends on" },
+  { value: "USES", labelPt: "Usa", labelEn: "Uses" },
+  { value: "CONTAINS", labelPt: "Cont\u00e9m", labelEn: "Contains" },
+  { value: "IMPACTS", labelPt: "Impacta", labelEn: "Impacts" },
+];
+
+const WORKSPACE_MODES: Record<string, { label: string; labelEn: string; types: string[] | null }> = {
+  all: { label: "Completo", labelEn: "All", types: null },
+  qa: { label: "QA", labelEn: "QA", types: ["Ticket", "Defect", "TestRun", "Screen", "Module"] },
+  automation: { label: "Automa\u00e7\u00e3o", labelEn: "Automation", types: ["Integration", "TestRun", "Screen", "Module", "Application"] },
+  docs: { label: "Docs", labelEn: "Docs", types: ["Note", "Module", "Application", "Company", "Release"] },
+  integrations: { label: "Integra\u00e7\u00f5es", labelEn: "Integrations", types: ["Integration", "Application", "Company", "Module"] },
+};
+
+const CONFIDENCE_LEVELS: Record<string, { label: string; color: string; colorDark: string }> = {
+  confiavel: { label: "Confi\u00e1vel", color: "#0f9f63", colorDark: "#2ddb87" },
+  inferido: { label: "Inferido", color: "#b45309", colorDark: "#fbbf24" },
+  velho: { label: "Desatualizado", color: "#6b7280", colorDark: "#9ca3af" },
+  contraditorio: { label: "Contradit\u00f3rio", color: "#dc2626", colorDark: "#f87171" },
+  pendente: { label: "Pendente", color: "#7c3aed", colorDark: "#c4b5fd" },
+};
+
+function getTypeAccent(type: string, isDark: boolean): string {
+  const map = isDark ? TYPE_ACCENTS_DARK : TYPE_ACCENTS_LIGHT;
+  return map[type] ?? (isDark ? "#c4cad3" : "#5f6875");
+}
+
 function useTheme() {
   const [isDark, setIsDark] = useState(() => {
     if (typeof document === "undefined") return true;
@@ -18,7 +222,10 @@ function useTheme() {
     const observer = new MutationObserver(() => {
       setIsDark(checkDark());
     });
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
 
     return () => observer.disconnect();
   }, []);
@@ -26,127 +233,191 @@ function useTheme() {
   return { isDark };
 }
 
-/* â”€â”€â”€ Testing Company Colors â”€â”€â”€ */
-const TC_PRIMARY = "#011848";  // Dark blue
-const TC_ACCENT = "#ef0001";   // Red
-
-/* â”€â”€â”€ Enhanced Color mapping per node type (dark mode) â”€â”€â”€ */
-const NODE_COLORS_DARK: Record<string, string> = {
-  Company: TC_ACCENT,          // Testing Company red
-  Application: "#9c27b0",
-  Module: "#ff6d00",
-  Ticket: "#ffab00",
-  Defect: "#ff1744",
-  User: "#00e676",
-  Screen: "#e91e63",
-  TestRun: "#2196f3",
-  Release: "#4caf50",
-  Integration: "#ce93d8",
-  Note: "#ffc107",
-};
-
-/* â”€â”€â”€ Enhanced Color mapping per node type (light mode) â”€â”€â”€ */
-const NODE_COLORS_LIGHT: Record<string, string> = {
-  Company: TC_PRIMARY,         // Testing Company blue
-  Application: "#7b1fa2",
-  Module: "#e65100",
-  Ticket: "#ff8f00",
-  Defect: TC_ACCENT,           // Testing Company red
-  User: "#00c853",
-  Screen: "#c2185b",
-  TestRun: "#1976d2",
-  Release: "#388e3c",
-  Integration: "#ab47bc",
-  Note: "#ffa000",
-};
-
-const MEMORY_TYPE_COLORS_DARK: Record<string, string> = {
-  DECISION: TC_ACCENT,
-  RULE: "#ff6d00",
-  PATTERN: "#7c4dff",
-  CONTEXT: "#00e676",
-  EXCEPTION: "#ff1744",
-  TECHNICAL_NOTE: "#ffd740",
-};
-
-const MEMORY_TYPE_COLORS_LIGHT: Record<string, string> = {
-  DECISION: TC_PRIMARY,
-  RULE: "#e65100",
-  PATTERN: "#651fff",
-  CONTEXT: "#00c853",
-  EXCEPTION: TC_ACCENT,
-  TECHNICAL_NOTE: "#ffa000",
-};
-
-/* â”€â”€â”€ Node type icons (emoji) â”€â”€â”€ */
-const NODE_ICONS: Record<string, string> = {
-  Company: "C",
-  Application: "A",
-  Module: "M",
-  Ticket: "T",
-  Defect: "D",
-  User: "U",
-  Screen: "S",
-  TestRun: "Q",
-  Release: "R",
-  Integration: "I",
-  Note: "N",
-};
-
-function getNodeColor(type: string, isDark: boolean) {
-  const colors = isDark ? NODE_COLORS_DARK : NODE_COLORS_LIGHT;
-  return colors[type] ?? (isDark ? "#78909c" : "#546e7a");
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
 }
 
-function getMemoryTypeColor(memoryType: string, isDark: boolean) {
-  const colors = isDark ? MEMORY_TYPE_COLORS_DARK : MEMORY_TYPE_COLORS_LIGHT;
-  return colors[memoryType] ?? (isDark ? "#607d8b" : "#455a64");
+function getGraphPalette(isDark: boolean) {
+  return isDark ? GRAPH_PALETTES.dark : GRAPH_PALETTES.light;
 }
 
-function getNodeIcon(type: string) {
-  return NODE_ICONS[type] ?? "*";
+function formatDate(value: string | undefined, locale: string) {
+  if (!value) return "-";
+
+  try {
+    return new Intl.DateTimeFormat(locale === "pt" ? "pt-BR" : "en-US", {
+      dateStyle: "short",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
 }
 
-function getNodeRadius(type: string, isRoot: boolean) {
-  if (isRoot) return 46;
-  if (type === "Company") return 38;
-  if (type === "Application" || type === "Module") return 30;
-  return 22;
+function dedupeMemories(memories: BrainMemory[]) {
+  const seen = new Set<string>();
+  return memories.filter((memory) => {
+    if (seen.has(memory.id)) return false;
+    seen.add(memory.id);
+    return true;
+  });
 }
 
-function lightenColor(hex: string, percent: number): string {
-  const num = parseInt(hex.slice(1), 16);
-  const r = Math.min(255, ((num >> 16) & 0xff) + percent);
-  const g = Math.min(255, ((num >> 8) & 0xff) + percent);
-  const b = Math.min(255, (num & 0xff) + percent);
-  return `rgb(${r}, ${g}, ${b})`;
+function getNodeRadius(node: SimNode, isFocused: boolean, isHovered: boolean) {
+  let radius = 3.2 + Math.min(node.degree, 9) * 0.5;
+
+  if (node.isRoot) radius += 2.4;
+  if (node.type === "Company" || node.type === "Application") radius += 0.9;
+  if (node.type === "Module") radius += 0.8;
+  if (isHovered) radius += 0.8;
+  if (isFocused) radius += 2.1;
+
+  return clamp(radius, 4, 13.5);
 }
 
-function darkenColor(hex: string, percent: number): string {
-  const num = parseInt(hex.slice(1), 16);
-  const r = Math.max(0, ((num >> 16) & 0xff) - percent);
-  const g = Math.max(0, ((num >> 8) & 0xff) - percent);
-  const b = Math.max(0, (num & 0xff) - percent);
-  return `rgb(${r}, ${g}, ${b})`;
+function buildSimulationGraph(
+  nodes: BrainNode[],
+  edges: BrainEdge[],
+  rootNodeId: string | null,
+) {
+  const degreeMap = new Map<string, number>();
+  const adjacencyMap = new Map<string, Set<string>>();
+
+  for (const node of nodes) {
+    degreeMap.set(node.id, 0);
+    adjacencyMap.set(node.id, new Set());
+  }
+
+  for (const edge of edges) {
+    degreeMap.set(edge.source, (degreeMap.get(edge.source) ?? 0) + 1);
+    degreeMap.set(edge.target, (degreeMap.get(edge.target) ?? 0) + 1);
+    adjacencyMap.get(edge.source)?.add(edge.target);
+    adjacencyMap.get(edge.target)?.add(edge.source);
+  }
+
+  const rootId =
+    rootNodeId ??
+    [...degreeMap.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ??
+    nodes[0]?.id ??
+    null;
+  const layerMap = new Map<string, number>();
+
+  if (rootId) {
+    const queue = [rootId];
+    layerMap.set(rootId, 0);
+
+    for (let index = 0; index < queue.length; index += 1) {
+      const currentId = queue[index];
+      const currentLayer = layerMap.get(currentId) ?? 0;
+
+      for (const neighborId of adjacencyMap.get(currentId) ?? []) {
+        if (layerMap.has(neighborId)) continue;
+        layerMap.set(neighborId, currentLayer + 1);
+        queue.push(neighborId);
+      }
+    }
+  }
+
+  let fallbackLayer = Math.max(0, ...Array.from(layerMap.values())) + 1;
+  for (const node of nodes) {
+    if (layerMap.has(node.id)) continue;
+    layerMap.set(node.id, fallbackLayer);
+    fallbackLayer += 1;
+  }
+
+  return { degreeMap, layerMap, rootId };
 }
 
-/* â”€â”€â”€ Force simulation types â”€â”€â”€ */
-type SimNode = BrainNode & { x: number; y: number; vx: number; vy: number; fx?: number | null; fy?: number | null };
+function getEdgeControlPoint(source: SimNode, target: SimNode) {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const distance = Math.sqrt(dx * dx + dy * dy) || 1;
+  const perpendicularX = -dy / distance;
+  const perpendicularY = dx / distance;
+  const curveStrength =
+    Math.min(22, Math.max(6, distance * 0.05)) *
+    (source.layer === target.layer ? 1.14 : 0.82);
+  const direction = source.id.localeCompare(target.id) <= 0 ? 1 : -1;
 
-function initSimulation(nodes: BrainNode[], edges: BrainEdge[], width: number, height: number) {
+  return {
+    controlX: (source.x + target.x) / 2 + perpendicularX * curveStrength * direction,
+    controlY: (source.y + target.y) / 2 + perpendicularY * curveStrength * direction,
+  };
+}
+
+function initSimulation(
+  nodes: BrainNode[],
+  edges: BrainEdge[],
+  width: number,
+  height: number,
+  rootNodeId: string | null,
+) {
+  const { degreeMap, layerMap, rootId } = buildSimulationGraph(nodes, edges, rootNodeId);
   const cx = width / 2;
   const cy = height / 2;
-  const spread = Math.min(Math.max(280, Math.sqrt(nodes.length) * 90), 760);
+  const maxLayer = Math.max(0, ...Array.from(layerMap.values()));
+  const layerSpacing = clamp(
+    Math.min(width, height) / Math.max(2.4, maxLayer + 1.8),
+    84,
+    156,
+  );
+  const ellipseScaleX = width >= height ? 1.16 : 1.02;
+  const ellipseScaleY = width >= height ? 0.84 : 0.94;
+  const layers = new Map<number, BrainNode[]>();
 
-  const simNodes: SimNode[] = nodes.map((n) => ({
-    ...n,
-    x: n.isRoot ? cx : cx + (Math.random() - 0.5) * spread,
-    y: n.isRoot ? cy : cy + (Math.random() - 0.5) * spread,
-    vx: 0,
-    vy: 0,
-    fx: n.isRoot ? cx : null,
-    fy: n.isRoot ? cy : null,
-  }));
+  for (const node of nodes) {
+    const layer = layerMap.get(node.id) ?? maxLayer + 1;
+    if (!layers.has(layer)) layers.set(layer, []);
+    layers.get(layer)?.push(node);
+  }
+
+  const simNodes: SimNode[] = [];
+
+  for (const [layer, group] of [...layers.entries()].sort((left, right) => left[0] - right[0])) {
+    const layerNodes = [...group].sort((left, right) => {
+      const leftType = NODE_TYPES.indexOf(left.type);
+      const rightType = NODE_TYPES.indexOf(right.type);
+      const leftOrder = leftType === -1 ? Number.MAX_SAFE_INTEGER : leftType;
+      const rightOrder = rightType === -1 ? Number.MAX_SAFE_INTEGER : rightType;
+      return (
+        leftOrder - rightOrder ||
+        (degreeMap.get(right.id) ?? 0) - (degreeMap.get(left.id) ?? 0) ||
+        left.label.localeCompare(right.label)
+      );
+    });
+    const angleStep = (Math.PI * 2) / Math.max(layerNodes.length, 1);
+
+    layerNodes.forEach((node, index) => {
+      const degree = degreeMap.get(node.id) ?? 0;
+      const phase = (TYPE_ORBIT_PHASE[node.type] ?? 0.5) * angleStep * 0.34;
+      const angle = -Math.PI / 2 + index * angleStep + phase + layer * 0.18;
+      const ringRadius = layer === 0 ? 0 : layerSpacing * (0.72 + layer * 0.88);
+      const radialBias = ((TYPE_RING_WEIGHTS[node.type] ?? 0.5) - 0.5) * layerSpacing * 0.36;
+      const ripple = Math.sin(angle * 3 + layer) * Math.min(layerSpacing * 0.12, 16);
+      const orbitRadius = Math.max(0, ringRadius + radialBias + ripple);
+      const anchorX =
+        node.id === rootId ? cx : cx + Math.cos(angle) * orbitRadius * ellipseScaleX;
+      const anchorY =
+        node.id === rootId ? cy : cy + Math.sin(angle) * orbitRadius * ellipseScaleY;
+      const initialJitter = node.id === rootId ? 0 : Math.min(10 + layer * 2, 18);
+
+      simNodes.push({
+        ...node,
+        degree,
+        layer,
+        orbitRadius,
+        anchorX,
+        anchorY,
+        x: anchorX + (Math.random() - 0.5) * initialJitter,
+        y: anchorY + (Math.random() - 0.5) * initialJitter,
+        vx: 0,
+        vy: 0,
+        fx: node.id === rootId ? cx : null,
+        fy: node.id === rootId ? cy : null,
+        mass: 1 + Math.min(degree, 10) * 0.06,
+      });
+    });
+  }
 
   return simNodes;
 }
@@ -154,60 +425,103 @@ function initSimulation(nodes: BrainNode[], edges: BrainEdge[], width: number, h
 function tickSimulation(simNodes: SimNode[], edges: BrainEdge[], width: number, height: number) {
   const cx = width / 2;
   const cy = height / 2;
-  const alpha = 0.35;
-  const nodeMap = new Map(simNodes.map((n) => [n.id, n]));
+  const nodeMap = new Map(simNodes.map((node) => [node.id, node]));
 
-  // Center gravity
   for (const node of simNodes) {
-    if (node.fx != null) { node.x = node.fx; node.y = node.fy!; continue; }
-    node.vx += (cx - node.x) * 0.0006;
-    node.vy += (cy - node.y) * 0.0006;
+    if (node.fx != null) {
+      node.x = node.fx;
+      node.y = node.fy ?? node.y;
+      continue;
+    }
+
+    const anchorStrength = 0.005 + node.layer * 0.00045;
+    node.vx += (node.anchorX - node.x) * anchorStrength;
+    node.vy += (node.anchorY - node.y) * anchorStrength;
+    node.vx += (cx - node.x) * 0.00004;
+    node.vy += (cy - node.y) * 0.00004;
   }
 
-  // Stronger repulsion for larger nodes
-  for (let i = 0; i < simNodes.length; i++) {
-    for (let j = i + 1; j < simNodes.length; j++) {
-      const a = simNodes[i];
-      const b = simNodes[j];
-      let dx = b.x - a.x;
-      let dy = b.y - a.y;
-      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-      const force = 2600 / (dist * dist);
-      dx = (dx / dist) * force;
-      dy = (dy / dist) * force;
-      if (a.fx == null) { a.vx -= dx; a.vy -= dy; }
-      if (b.fx == null) { b.vx += dx; b.vy += dy; }
+  for (let index = 0; index < simNodes.length; index += 1) {
+    for (let second = index + 1; second < simNodes.length; second += 1) {
+      const firstNode = simNodes[index];
+      const secondNode = simNodes[second];
+
+      let dx = secondNode.x - firstNode.x;
+      let dy = secondNode.y - firstNode.y;
+      const distance = Math.sqrt(dx * dx + dy * dy) || 1;
+      const safeDistance = Math.max(distance, 18);
+      const sameLayerBand = Math.abs(firstNode.layer - secondNode.layer) <= 1;
+      const moduleBoost =
+        firstNode.type === "Module" || secondNode.type === "Module" ? 1.24 : 1;
+      const hubBoost =
+        firstNode.degree >= 5 || secondNode.degree >= 5 || firstNode.isRoot || secondNode.isRoot
+          ? 1.12
+          : 1;
+      const repelStrength = Math.min(
+        28,
+        (7000 * (sameLayerBand ? 1.18 : 0.92) * moduleBoost * hubBoost) /
+          (safeDistance * safeDistance),
+      );
+
+      dx = (dx / safeDistance) * repelStrength;
+      dy = (dy / safeDistance) * repelStrength;
+
+      if (firstNode.fx == null) {
+        firstNode.vx -= dx / firstNode.mass;
+        firstNode.vy -= dy / firstNode.mass;
+      }
+
+      if (secondNode.fx == null) {
+        secondNode.vx += dx / secondNode.mass;
+        secondNode.vy += dy / secondNode.mass;
+      }
     }
   }
 
-  // Attraction via edges with longer rest length
   for (const edge of edges) {
-    const a = nodeMap.get(edge.source);
-    const b = nodeMap.get(edge.target);
-    if (!a || !b) continue;
-    let dx = b.x - a.x;
-    let dy = b.y - a.y;
-    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-    const force = (dist - 220) * 0.0045;
-    dx = (dx / dist) * force;
-    dy = (dy / dist) * force;
-    if (a.fx == null) { a.vx += dx; a.vy += dy; }
-    if (b.fx == null) { b.vx -= dx; b.vy -= dy; }
+    const fromNode = nodeMap.get(edge.source);
+    const toNode = nodeMap.get(edge.target);
+    if (!fromNode || !toNode) continue;
+
+    let dx = toNode.x - fromNode.x;
+    let dy = toNode.y - fromNode.y;
+    const distance = Math.sqrt(dx * dx + dy * dy) || 1;
+    const layerDelta = Math.abs(fromNode.layer - toNode.layer);
+    const moduleLink =
+      fromNode.type === "Module" || toNode.type === "Module" ? 18 : 0;
+    const restLength =
+      108 +
+      layerDelta * 24 +
+      Math.min((fromNode.degree + toNode.degree) * 4, 58) +
+      moduleLink;
+    const attraction = (distance - restLength) * (moduleLink > 0 ? 0.0032 : 0.0027);
+
+    dx = (dx / distance) * attraction;
+    dy = (dy / distance) * attraction;
+
+    if (fromNode.fx == null) {
+      fromNode.vx += dx / fromNode.mass;
+      fromNode.vy += dy / fromNode.mass;
+    }
+
+    if (toNode.fx == null) {
+      toNode.vx -= dx / toNode.mass;
+      toNode.vy -= dy / toNode.mass;
+    }
   }
 
-  // Apply velocity with damping
   for (const node of simNodes) {
     if (node.fx != null) continue;
-    node.vx *= 0.55;
-    node.vy *= 0.55;
-    node.x += node.vx * alpha;
-    node.y += node.vy * alpha;
-    node.x = Math.max(84, Math.min(width - 84, node.x));
-    node.y = Math.max(84, Math.min(height - 84, node.y));
+
+    node.vx *= 0.82;
+    node.vy *= 0.82;
+    node.x += node.vx;
+    node.y += node.vy;
+    node.x = clamp(node.x, 40, width - 40);
+    node.y = clamp(node.y, 40, height - 40);
   }
 }
 
-/* â”€â”€â”€ Main component â”€â”€â”€ */
 export default function BrainGraphView() {
   const { t, locale } = useTranslation();
   const { isDark } = useTheme();
@@ -216,24 +530,68 @@ export default function BrainGraphView() {
   const [rootNodeId, setRootNodeId] = useState<string | null>(null);
   const [searchText, setSearchText] = useState("");
   const [filterType, setFilterType] = useState<string | null>(null);
-  const [depth, setDepth] = useState(3);
-  const [panelOpen, setPanelOpen] = useState(false);
+  const [depth, setDepth] = useState(MAX_GRAPH_DEPTH);
+  const [panelOpen, setPanelOpen] = useState(true);
   const [viewScale, setViewScale] = useState(1);
+  const [showLabels, setShowLabels] = useState(false);
+  const [activeTab, setActiveTab] = useState<"info" | "ask" | "create" | "timeline">("info");
+  const [showEdgeLabels, setShowEdgeLabels] = useState(true);
+  const [workspaceMode, setWorkspaceMode] = useState<keyof typeof WORKSPACE_MODES>("all");
+  const [showExplorer, setShowExplorer] = useState(false);
+  const [explorerCollapsed, setExplorerCollapsed] = useState<Set<string>>(new Set());
+  const [showPalette, setShowPalette] = useState(false);
+  const [paletteQuery, setPaletteQuery] = useState("");
+  const paletteInputRef = useRef<HTMLInputElement>(null);
+
+  // Create node form state
+  const [createNodeLabel, setCreateNodeLabel] = useState("");
+  const [createNodeType, setCreateNodeType] = useState("Note");
+  const [createNodeDesc, setCreateNodeDesc] = useState("");
+  const [createNodeLinkType, setCreateNodeLinkType] = useState("RELATES_TO");
+  const [createNodeAttachToSelection, setCreateNodeAttachToSelection] = useState(true);
+  const [createNodeLoading, setCreateNodeLoading] = useState(false);
+  const [createNodeError, setCreateNodeError] = useState<string | null>(null);
+  const [deleteNodeLoading, setDeleteNodeLoading] = useState(false);
+  const [deleteNodeError, setDeleteNodeError] = useState<string | null>(null);
+  const [syncLoading, setSyncLoading] = useState(false);
+  const [syncResult, setSyncResult] = useState<{ nodes: number; edges: number } | null>(null);
+
+  const deferredSearchText = useDeferredValue(searchText.trim());
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const simNodesRef = useRef<SimNode[]>([]);
-  const animFrameRef = useRef<number | undefined>(undefined);
+  const animationFrameRef = useRef<number | undefined>(undefined);
   const dragRef = useRef<{ nodeId: string; offsetX: number; offsetY: number } | null>(null);
   const panRef = useRef({ x: 0, y: 0, scale: 1, dragging: false, lastX: 0, lastY: 0 });
+  const chatContainerRef = useRef<HTMLDivElement>(null);
 
-  const { data: graphData, isLoading: graphLoading } = useBrainGraph(rootNodeId, depth);
-  const { data: stats } = useBrainStats();
-  const { data: nodeContext } = useBrainNodeContext(selectedNodeId, depth);
-  const { data: memoriesData } = useBrainMemories(selectedNodeId);
+  // Custom streaming chat state
+  type ChatMessage = { id: string; role: "user" | "assistant"; content: string };
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
+  const [chatInput, setChatInput] = useState("");
+  const [chatLoading, setChatLoading] = useState(false);
 
-  const nodes = graphData?.nodes ?? [];
-  const edges = graphData?.edges ?? [];
-  const memories: BrainMemory[] = memoriesData?.memories ?? [];
+  const { data: graphData, isLoading: graphLoading, mutate: mutateGraph } = useBrainGraph(rootNodeId, depth);
+  const { data: stats, mutate: mutateStats } = useBrainStats();
+  const { data: nodeContext, mutate: mutateNodeContext } = useBrainNodeContext(selectedNodeId, depth);
+  const { data: searchData, isLoading: searchLoading } = useBrainSearch(
+    deferredSearchText.length >= 2 ? deferredSearchText : undefined,
+    filterType ?? undefined,
+    8,
+  );
+  const { data: timelineData, mutate: mutateTimeline } = useBrainTimeline(selectedNodeId);
+  const deferredPaletteQuery = useDeferredValue(paletteQuery.trim());
+  const { data: paletteSearchData } = useBrainSearch(
+    deferredPaletteQuery.length >= 1 ? deferredPaletteQuery : undefined,
+    undefined,
+    12,
+  );
+
+  const nodes = graphData?.nodes ?? EMPTY_NODES;
+  const edges = graphData?.edges ?? EMPTY_EDGES;
+  const effectiveRootNodeId = rootNodeId ?? graphData?.root?.id ?? null;
+  const visibleRootNode =
+    nodes.find((node) => node.id === effectiveRootNodeId) ?? graphData?.root ?? null;
 
   useEffect(() => {
     if (selectedNodeId) {
@@ -242,356 +600,831 @@ export default function BrainGraphView() {
     }
   }, [selectedNodeId]);
 
-  // Filter nodes
-  const filteredNodes = nodes.filter((n) => {
-    if (filterType && n.type !== filterType) return false;
-    if (searchText && !n.label.toLowerCase().includes(searchText.toLowerCase())) return false;
-    return true;
-  });
+  // Focus palette input when opened
+  useEffect(() => {
+    if (showPalette) {
+      const t = setTimeout(() => paletteInputRef.current?.focus(), 30);
+      return () => clearTimeout(t);
+    }
+  }, [showPalette]);
 
-  const filteredEdges = edges.filter((e) => {
-    const sourceOk = filteredNodes.some((n) => n.id === e.source);
-    const targetOk = filteredNodes.some((n) => n.id === e.target);
-    return sourceOk && targetOk;
-  });
+  // Auto-scroll chat to bottom on new messages
+  useEffect(() => {
+    if (chatContainerRef.current && chatMessages.length > 0) {
+      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
+    }
+  }, [chatMessages]);
 
-  // Initialize simulation when data changes
+  const filteredNodes = useMemo(
+    () =>
+      nodes.filter((node) => {
+        if (filterType && node.type !== filterType) return false;
+        const workspaceTypes = WORKSPACE_MODES[workspaceMode]?.types;
+        if (workspaceTypes && !workspaceTypes.includes(node.type)) return false;
+        return true;
+      }),
+    [filterType, nodes, workspaceMode],
+  );
+
+  const filteredEdges = useMemo(() => {
+    const visibleNodeIds = new Set(filteredNodes.map((node) => node.id));
+    return edges.filter(
+      (edge) => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target),
+    );
+  }, [edges, filteredNodes]);
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || filteredNodes.length === 0) return;
 
     const { width, height } = canvas.getBoundingClientRect();
-    canvas.width = width * (window.devicePixelRatio || 1);
-    canvas.height = height * (window.devicePixelRatio || 1);
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
 
-    simNodesRef.current = initSimulation(filteredNodes, filteredEdges, width, height);
-  }, [filteredEdges, filteredNodes, filterType, searchText]);
+    simNodesRef.current = initSimulation(
+      filteredNodes,
+      filteredEdges,
+      width,
+      height,
+      effectiveRootNodeId,
+    );
+  }, [filteredEdges, filteredNodes, effectiveRootNodeId]);
 
-  // Render loop
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || filteredNodes.length === 0) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const { width, height } = canvas.getBoundingClientRect();
+      if (!width || !height) return;
+
+      for (let step = 0; step < 140; step += 1) {
+        tickSimulation(simNodesRef.current, filteredEdges, width, height);
+      }
+
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+
+      for (const node of simNodesRef.current) {
+        minX = Math.min(minX, node.x);
+        maxX = Math.max(maxX, node.x);
+        minY = Math.min(minY, node.y);
+        maxY = Math.max(maxY, node.y);
+      }
+
+      const padding = 92;
+      const graphW = maxX - minX + padding * 2;
+      const graphH = maxY - minY + padding * 2;
+      const scale = clamp(Math.min(width / graphW, height / graphH), 0.32, 2.3);
+
+      panRef.current.scale = scale;
+      panRef.current.x = width / 2 - ((minX + maxX) / 2) * scale;
+      panRef.current.y = height / 2 - ((minY + maxY) / 2) * scale;
+      setViewScale(Number(scale.toFixed(2)));
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [effectiveRootNodeId, filteredEdges, filteredNodes.length]);
+
+  const selectedNode = nodeContext?.context?.node ?? nodes.find((node) => node.id === selectedNodeId) ?? null;
+  const nodeNeighbors = nodeContext?.context?.neighbors ?? EMPTY_NODES;
+  const nodeOutgoing = nodeContext?.context?.outgoing ?? EMPTY_CONTEXT_EDGES;
+  const nodeIncoming = nodeContext?.context?.incoming ?? EMPTY_CONTEXT_EDGES;
+  const impactData = nodeContext?.impact;
+  const impactedNodes = impactData?.impactedNodes ?? EMPTY_NODES;
+  const impactPaths = impactData?.paths ?? EMPTY_IMPACT_PATHS;
+  const directMemories = dedupeMemories(nodeContext?.memories ?? EMPTY_MEMORIES);
+  const relatedMemories = dedupeMemories([
+    ...(nodeContext?.relatedMemories ?? EMPTY_MEMORIES),
+    ...directMemories,
+  ]);
+  const ancestors = nodeContext?.ancestors ?? EMPTY_NODES;
+  const descendants = nodeContext?.descendants ?? EMPTY_NODES;
+  const suggestions = nodeContext?.suggestions ?? EMPTY_SUGGESTIONS;
+  const similarNodes = nodeContext?.similarNodes ?? EMPTY_NODES;
+  const topNodeTypes = stats?.breakdown.nodesByType.slice(0, 6) ?? [];
+  const topConnectedNodes = stats?.topConnectedNodes ?? [];
+  const recentActivity = stats?.recentActivity?.slice(0, 6) ?? [];
+  const alerts = stats?.alerts ?? [];
+  const graphMetrics = stats?.graphMetrics;
+  const nodeTimeline = (timelineData?.timeline ?? []) as BrainTimelineEntry[];
+  const paletteNodes = paletteSearchData?.nodes ?? [];
+
+  // Group all visible nodes by type for explorer
+  const nodesByType = useMemo(() => {
+    const map = new Map<string, BrainNode[]>();
+    for (const node of nodes) {
+      if (!map.has(node.type)) map.set(node.type, []);
+      map.get(node.type)!.push(node);
+    }
+    return map;
+  }, [nodes]);
+  const intelligenceScore = stats?.intelligenceScore ?? 0;
+  const searchResults = searchData?.nodes ?? [];
+  const showSearchResults =
+    deferredSearchText.length >= 2 && (searchLoading || searchResults.length > 0);
+  const nodeTypes = useMemo(
+    () => Array.from(new Set(nodes.map((node) => node.type))).sort(),
+    [nodes],
+  );
+  const isPanelVisible = panelOpen && (!!selectedNode || !!stats);
+  const activeRootLabel = visibleRootNode?.label ?? (effectiveRootNodeId ? effectiveRootNodeId.slice(0, 8) : null);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Ctrl/Cmd+K = command palette
+      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
+        e.preventDefault();
+        setShowPalette((v) => !v);
+        setPaletteQuery("");
+        return;
+      }
+      if (e.key === "Escape") {
+        if (showPalette) { setShowPalette(false); return; }
+        setSelectedNodeId(null);
+        setHoveredNodeId(null);
+        return;
+      }
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === "f" || e.key === "F") zoomToFit();
+      if (e.key === "l" || e.key === "L") setShowLabels((v) => !v);
+      if (e.key === "p" || e.key === "P") setPanelOpen((v) => !v);
+      if (e.key === "e" || e.key === "E") setShowExplorer((v) => !v);
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showPalette]);
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
 
-    let time = 0;
-
-    // Theme-aware colors
-    const bgColors = isDark
-      ? { c1: TC_PRIMARY, c2: "#0a1220", c3: "#050a12" }      // Dark: TC blue base
-      : { c1: "#f8fafc", c2: "#f1f5f9", c3: "#e2e8f0" };      // Light: slate grays
-    const gridColor = isDark
-      ? `rgba(239, 0, 1, 0.04)`   // TC red subtle
-      : `rgba(1, 24, 72, 0.06)`;  // TC blue subtle
-    const accentColor = isDark ? TC_ACCENT : TC_PRIMARY;
+    const palette = getGraphPalette(isDark);
 
     const render = () => {
-      time += 0.02;
       const { width, height } = canvas.getBoundingClientRect();
       const dpr = window.devicePixelRatio || 1;
+
       if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
         canvas.width = width * dpr;
         canvas.height = height * dpr;
       }
 
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      
-      // Background gradient
-      const bgGrad = ctx.createRadialGradient(width / 2, height / 2, 0, width / 2, height / 2, Math.max(width, height) * 0.7);
-      bgGrad.addColorStop(0, bgColors.c1);
-      bgGrad.addColorStop(0.5, bgColors.c2);
-      bgGrad.addColorStop(1, bgColors.c3);
-      ctx.fillStyle = bgGrad;
-      ctx.fillRect(0, 0, width, height);
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-      // Animated grid pattern
-      ctx.strokeStyle = gridColor;
-      ctx.lineWidth = 1;
-      const gridSize = 60;
-      for (let x = (time * 10) % gridSize; x < width; x += gridSize) {
-        ctx.beginPath();
-        ctx.moveTo(x, 0);
-        ctx.lineTo(x, height);
-        ctx.stroke();
-      }
-      for (let y = (time * 10) % gridSize; y < height; y += gridSize) {
-        ctx.beginPath();
-        ctx.moveTo(0, y);
-        ctx.lineTo(width, y);
-        ctx.stroke();
-      }
+      // Background radial gradient
+      const gradient = context.createRadialGradient(
+        width / 2,
+        height / 2,
+        0,
+        width / 2,
+        height / 2,
+        Math.max(width, height) * 0.76,
+      );
+      gradient.addColorStop(0, palette.bgGlow);
+      gradient.addColorStop(0.45, palette.bgInner);
+      gradient.addColorStop(1, palette.bgOuter);
+      context.fillStyle = gradient;
+      context.fillRect(0, 0, width, height);
 
-      const pan = panRef.current;
-      ctx.save();
-      ctx.translate(pan.x, pan.y);
-      ctx.scale(pan.scale, pan.scale);
+      context.save();
+      context.translate(panRef.current.x, panRef.current.y);
+      context.scale(panRef.current.scale, panRef.current.scale);
 
       const simNodes = simNodesRef.current;
-      const nodeMap = new Map(simNodes.map((n) => [n.id, n]));
-
       tickSimulation(simNodes, filteredEdges, width, height);
 
-      // Draw curved edges with gradients
-      for (const edge of filteredEdges) {
-        const from = nodeMap.get(edge.source);
-        const to = nodeMap.get(edge.target);
-        if (!from || !to) continue;
+      const accentNodeIds = new Set<string>();
+      if (effectiveRootNodeId) accentNodeIds.add(effectiveRootNodeId);
+      if (selectedNodeId) accentNodeIds.add(selectedNodeId);
+      if (hoveredNodeId) accentNodeIds.add(hoveredNodeId);
+      for (const node of nodeNeighbors.slice(0, 12)) accentNodeIds.add(node.id);
+      for (const node of impactedNodes.slice(0, 12)) accentNodeIds.add(node.id);
 
-        const isHighlighted = (selectedNodeId || hoveredNodeId) && 
-          (edge.source === selectedNodeId || edge.target === selectedNodeId ||
-           edge.source === hoveredNodeId || edge.target === hoveredNodeId);
-        
-        const fromColor = getNodeColor(from.type, isDark);
-        const toColor = getNodeColor(to.type, isDark);
-        
-        // Calculate curve control point
-        const midX = (from.x + to.x) / 2;
-        const midY = (from.y + to.y) / 2;
-        const dx = to.x - from.x;
-        const dy = to.y - from.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        const curvature = Math.min(dist * 0.15, 40);
-        const cpX = midX - dy * curvature / dist;
-        const cpY = midY + dx * curvature / dist;
-        
-        // Edge glow for highlighted
-        if (isHighlighted) {
-          ctx.beginPath();
-          ctx.moveTo(from.x, from.y);
-          ctx.quadraticCurveTo(cpX, cpY, to.x, to.y);
-          const glowAlpha = 0.3 + Math.sin(time * 3) * 0.1;
-          ctx.strokeStyle = isDark
-            ? `rgba(239, 0, 1, ${glowAlpha})`     // TC red glow
-            : `rgba(1, 24, 72, ${glowAlpha})`;   // TC blue glow
-          ctx.lineWidth = 8;
-          ctx.stroke();
-        }
-        
-        // Edge gradient
-        const edgeGrad = ctx.createLinearGradient(from.x, from.y, to.x, to.y);
-        edgeGrad.addColorStop(0, isHighlighted ? fromColor : fromColor + "80");
-        edgeGrad.addColorStop(1, isHighlighted ? toColor : toColor + "80");
-        
-        ctx.beginPath();
-        ctx.moveTo(from.x, from.y);
-        ctx.quadraticCurveTo(cpX, cpY, to.x, to.y);
-        ctx.strokeStyle = edgeGrad;
-        ctx.lineWidth = isHighlighted ? 3 : 2;
-        ctx.stroke();
-        
-        // Animated particle on highlighted edges
-        if (isHighlighted) {
-          const t = (time * 0.3) % 1;
-          const px = (1 - t) * (1 - t) * from.x + 2 * (1 - t) * t * cpX + t * t * to.x;
-          const py = (1 - t) * (1 - t) * from.y + 2 * (1 - t) * t * cpY + t * t * to.y;
-          ctx.beginPath();
-          ctx.arc(px, py, 4, 0, Math.PI * 2);
-          ctx.fillStyle = accentColor;
-          ctx.fill();
+      const nodeMap = new Map(simNodes.map((node) => [node.id, node]));
+
+      const rootNode = effectiveRootNodeId ? nodeMap.get(effectiveRootNodeId) : null;
+      const selectedNode = selectedNodeId ? nodeMap.get(selectedNodeId) : null;
+
+      if (rootNode) {
+        const rootGlow = context.createRadialGradient(
+          rootNode.x,
+          rootNode.y,
+          0,
+          rootNode.x,
+          rootNode.y,
+          160,
+        );
+        rootGlow.addColorStop(0, palette.haloHub);
+        rootGlow.addColorStop(1, "rgba(0, 0, 0, 0)");
+        context.fillStyle = rootGlow;
+        context.beginPath();
+        context.arc(rootNode.x, rootNode.y, 160, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      if (selectedNode && selectedNode.id !== rootNode?.id) {
+        const selectedGlow = context.createRadialGradient(
+          selectedNode.x,
+          selectedNode.y,
+          0,
+          selectedNode.x,
+          selectedNode.y,
+          120,
+        );
+        selectedGlow.addColorStop(0, palette.haloFocus);
+        selectedGlow.addColorStop(1, "rgba(0, 0, 0, 0)");
+        context.fillStyle = selectedGlow;
+        context.beginPath();
+        context.arc(selectedNode.x, selectedNode.y, 120, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      // Draw edges with arrowheads
+      for (const edge of filteredEdges) {
+        const source = nodeMap.get(edge.source);
+        const target = nodeMap.get(edge.target);
+        if (!source || !target) continue;
+
+        const connectedToSelection =
+          selectedNodeId != null &&
+          (edge.source === selectedNodeId || edge.target === selectedNodeId);
+        const connectedToRoot =
+          effectiveRootNodeId != null &&
+          (edge.source === effectiveRootNodeId || edge.target === effectiveRootNodeId);
+        const activeEdge =
+          accentNodeIds.has(edge.source) || accentNodeIds.has(edge.target);
+
+        const edgeColor = connectedToSelection
+          ? palette.edgeFocus
+          : connectedToRoot
+            ? palette.edgeHub
+            : activeEdge
+            ? palette.edgeActive
+            : palette.edgeMuted;
+        const lineWidth = connectedToSelection ? 2.25 : connectedToRoot ? 1.7 : activeEdge ? 1.45 : 1.05;
+        const { controlX, controlY } = getEdgeControlPoint(source, target);
+
+        // Draw line
+        context.beginPath();
+        context.moveTo(source.x, source.y);
+        context.quadraticCurveTo(controlX, controlY, target.x, target.y);
+        context.strokeStyle = edgeColor;
+        context.lineWidth = lineWidth;
+        context.shadowColor = connectedToSelection
+          ? palette.edgeGlowFocus
+          : connectedToRoot
+            ? palette.edgeGlowHub
+            : activeEdge
+              ? palette.edgeGlowActive
+              : "transparent";
+        context.shadowBlur = connectedToSelection ? 16 : connectedToRoot ? 12 : activeEdge ? 8 : 0;
+        context.stroke();
+        context.shadowBlur = 0;
+
+        // Draw arrowhead at target
+        const targetNode = target;
+        const tRadius = getNodeRadius(
+          targetNode,
+          targetNode.id === selectedNodeId || targetNode.id === effectiveRootNodeId,
+          targetNode.id === hoveredNodeId,
+        );
+        const angle = Math.atan2(target.y - controlY, target.x - controlX);
+        const arrowSize = connectedToSelection ? 7 : connectedToRoot ? 6 : activeEdge ? 5.5 : 4;
+        const arrowX = target.x - Math.cos(angle) * (tRadius + 1.5);
+        const arrowY = target.y - Math.sin(angle) * (tRadius + 1.5);
+
+        context.beginPath();
+        context.moveTo(arrowX, arrowY);
+        context.lineTo(
+          arrowX - arrowSize * Math.cos(angle - Math.PI / 6),
+          arrowY - arrowSize * Math.sin(angle - Math.PI / 6),
+        );
+        context.lineTo(
+          arrowX - arrowSize * Math.cos(angle + Math.PI / 6),
+          arrowY - arrowSize * Math.sin(angle + Math.PI / 6),
+        );
+        context.closePath();
+        context.fillStyle = connectedToSelection
+          ? palette.arrowFocus
+          : connectedToRoot
+            ? palette.arrowHub
+            : activeEdge
+            ? palette.arrowActive
+            : palette.arrow;
+        context.fill();
+
+        // Edge type label at midpoint (only for selected edges + when showEdgeLabels)
+        if (showEdgeLabels && connectedToSelection) {
+          const midX = (source.x + 2 * controlX + target.x) / 4;
+          const midY = (source.y + 2 * controlY + target.y) / 4;
+          const edgeLabel = edge.type.replace(/_/g, " ").toLowerCase();
+
+          context.save();
+          context.font = '500 9px "Poppins", "Segoe UI", system-ui, sans-serif';
+          context.textAlign = "center";
+          context.textBaseline = "middle";
+          context.shadowColor = palette.labelShadow;
+          context.shadowBlur = 8;
+          context.fillStyle = palette.edgeLabel;
+          context.fillText(edgeLabel, midX, midY - 6);
+          context.shadowBlur = 0;
+          context.restore();
         }
       }
 
-      // Draw nodes (sorted sÃ³ selected is on top)
-      const sortedNodes = [...simNodes].sort((a, b) => {
-        if (a.id === selectedNodeId) return 1;
-        if (b.id === selectedNodeId) return -1;
-        if (a.id === hoveredNodeId) return 1;
-        if (b.id === hoveredNodeId) return -1;
-        return 0;
+      // Sort nodes for z-ordering
+      const sortedNodes = [...simNodes].sort((left, right) => {
+        const leftWeight =
+          (left.id === selectedNodeId ? 100 : 0) +
+          (left.id === hoveredNodeId ? 50 : 0) +
+          (left.id === effectiveRootNodeId ? 25 : 0) +
+          left.degree;
+        const rightWeight =
+          (right.id === selectedNodeId ? 100 : 0) +
+          (right.id === hoveredNodeId ? 50 : 0) +
+          (right.id === effectiveRootNodeId ? 25 : 0) +
+          right.degree;
+        return leftWeight - rightWeight;
       });
 
-      // Theme-aware node colors
-      const labelBg = isDark ? "rgba(10, 15, 30, 0.85)" : "rgba(255, 255, 255, 0.95)";
-      const labelText = isDark ? "#ffffff" : TC_PRIMARY;
-      const borderDefault = isDark ? "rgba(255,255,255,0.3)" : "rgba(1, 24, 72, 0.3)";
-      const borderSelected = isDark ? "#ffffff" : TC_PRIMARY;
-
       for (const node of sortedNodes) {
-        const color = getNodeColor(node.type, isDark);
-        const baseRadius = getNodeRadius(node.type, node.isRoot ?? false);
         const isSelected = node.id === selectedNodeId;
+        const isRoot = node.id === effectiveRootNodeId;
+        const isFocused = isSelected || isRoot;
         const isHovered = node.id === hoveredNodeId;
-        const radius = baseRadius + (isSelected ? 6 : isHovered ? 3 : 0);
-        
-        // Outer glow ring (animated)
-        if (isSelected || isHovered || node.isRoot) {
-          const glowRadius = radius + 20 + Math.sin(time * 2) * 4;
-          const glowGrad = ctx.createRadialGradient(node.x, node.y, radius, node.x, node.y, glowRadius);
-          glowGrad.addColorStop(0, color + "50");
-          glowGrad.addColorStop(0.6, color + "20");
-          glowGrad.addColorStop(1, "transparent");
-          ctx.beginPath();
-          ctx.arc(node.x, node.y, glowRadius, 0, Math.PI * 2);
-          ctx.fillStyle = glowGrad;
-          ctx.fill();
+        const isSignal = accentNodeIds.has(node.id);
+        const isHub = node.degree >= 4 || node.isRoot;
+        const radius = getNodeRadius(node, isFocused, isHovered);
+
+        // Type-based color (Obsidian-inspired: each type has its own color)
+        const typeColor = getTypeAccent(node.type, isDark);
+        const fill = isSelected
+          ? palette.nodeFocus
+          : isRoot
+            ? palette.nodeHub
+          : isHovered
+            ? typeColor
+            : isSignal
+              ? typeColor
+              : isHub
+                ? typeColor
+                : node.degree <= 1
+                  ? (isDark ? `${typeColor}99` : `${typeColor}bb`)
+                  : typeColor;
+
+        // Halo for focused/hovered
+        if (isFocused || isHovered) {
+          context.beginPath();
+          context.arc(node.x, node.y, radius + (isSelected ? 13 : isRoot ? 11 : 10), 0, Math.PI * 2);
+          context.fillStyle = isSelected
+            ? palette.haloFocus
+            : isRoot
+              ? palette.haloHub
+              : `${typeColor}22`;
+          context.fill();
         }
 
-        // Shadow
-        ctx.beginPath();
-        ctx.arc(node.x + 3, node.y + 3, radius, 0, Math.PI * 2);
-        ctx.fillStyle = isDark ? "rgba(0, 0, 0, 0.3)" : "rgba(0, 0, 0, 0.15)";
-        ctx.fill();
+        // Node circle
+        context.beginPath();
+        context.arc(node.x, node.y, radius, 0, Math.PI * 2);
+        context.fillStyle = fill;
+        context.shadowColor = isSelected
+          ? palette.haloFocus
+          : isRoot
+            ? palette.haloHub
+            : isSignal
+              ? `${typeColor}44`
+              : "transparent";
+        context.shadowBlur = isSelected ? 18 : isRoot ? 14 : isSignal ? 8 : 0;
+        context.fill();
+        context.shadowBlur = 0;
 
-        // Node fill with gradient
-        const nodeGrad = ctx.createRadialGradient(node.x - radius * 0.3, node.y - radius * 0.3, 0, node.x, node.y, radius);
-        nodeGrad.addColorStop(0, lightenColor(color, isDark ? 40 : 30));
-        nodeGrad.addColorStop(0.7, color);
-        nodeGrad.addColorStop(1, darkenColor(color, isDark ? 30 : 20));
-        ctx.beginPath();
-        ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
-        ctx.fillStyle = nodeGrad;
-        ctx.fill();
-        
-        // Border ring
-        ctx.strokeStyle = isSelected ? borderSelected : isHovered ? lightenColor(color, 50) : borderDefault;
-        ctx.lineWidth = isSelected ? 4 : isHovered ? 3 : 2;
-        ctx.stroke();
+        // Confidence ring (check node.metadata.confidence)
+        const confidence = (node.metadata as Record<string, unknown> | null)?.confidence as string | undefined;
+        if (confidence && CONFIDENCE_LEVELS[confidence]) {
+          const confColor = isDark
+            ? CONFIDENCE_LEVELS[confidence].colorDark
+            : CONFIDENCE_LEVELS[confidence].color;
+          context.beginPath();
+          context.arc(node.x, node.y, radius + 3.5, 0, Math.PI * 2);
+          context.strokeStyle = confColor;
+          context.lineWidth = 2;
+          context.setLineDash([3, 3]);
+          context.stroke();
+          context.setLineDash([]);
+        }
 
-        // Inner highlight (glass effect)
-        ctx.beginPath();
-        ctx.arc(node.x, node.y - radius * 0.2, radius * 0.7, Math.PI, 0);
-        const innerGrad = ctx.createLinearGradient(node.x, node.y - radius, node.x, node.y);
-        innerGrad.addColorStop(0, "rgba(255,255,255,0.35)");
-        innerGrad.addColorStop(1, "transparent");
-        ctx.fillStyle = innerGrad;
-        ctx.fill();
+        // Focus ring
+        if (isFocused) {
+          context.beginPath();
+          context.arc(node.x, node.y, radius + 2.4, 0, Math.PI * 2);
+          context.strokeStyle = isSelected ? palette.nodeFocus : palette.nodeHub;
+          context.lineWidth = 1.1;
+          context.stroke();
+        }
 
-        // Icon inside node
-        const icon = getNodeIcon(node.type);
-        ctx.font = `${radius * 0.8}px system-ui, sans-serif`;
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillStyle = "rgba(255,255,255,0.95)";
-        ctx.fillText(icon, node.x, node.y);
+        // Labels
+        const shouldShowLabel =
+          showLabels ||
+          isFocused ||
+          isHovered ||
+          (node.type === "Module" && simNodes.length <= 48);
+        if (!shouldShowLabel) {
+          continue;
+        }
 
-        // Label with rounded background
-        const label = node.label.length > 22 ? `${node.label.slice(0, 20)}...` : node.label;
-        ctx.font = `${isSelected ? "bold " : ""}${radius > 26 ? 14 : 12}px Inter, system-ui, sans-serif`;
-        const labelWidth = ctx.measureText(label).width;
-        const labelY = node.y + radius + 14;
-        
-        // Label background pill
-        ctx.beginPath();
-        const pillPadX = 8, pillPadY = 4;
-        const pillX = node.x - labelWidth / 2 - pillPadX;
-        const pillY = labelY - 8 - pillPadY;
-        const pillW = labelWidth + pillPadX * 2;
-        const pillH = 18 + pillPadY;
-        const pillR = 8;
-        ctx.moveTo(pillX + pillR, pillY);
-        ctx.lineTo(pillX + pillW - pillR, pillY);
-        ctx.arcTo(pillX + pillW, pillY, pillX + pillW, pillY + pillR, pillR);
-        ctx.lineTo(pillX + pillW, pillY + pillH - pillR);
-        ctx.arcTo(pillX + pillW, pillY + pillH, pillX + pillW - pillR, pillY + pillH, pillR);
-        ctx.lineTo(pillX + pillR, pillY + pillH);
-        ctx.arcTo(pillX, pillY + pillH, pillX, pillY + pillH - pillR, pillR);
-        ctx.lineTo(pillX, pillY + pillR);
-        ctx.arcTo(pillX, pillY, pillX + pillR, pillY, pillR);
-        ctx.closePath();
-        ctx.fillStyle = labelBg;
-        ctx.fill();
-        ctx.strokeStyle = color + "60";
-        ctx.lineWidth = 1;
-        ctx.stroke();
+        const labelX = node.x + radius + 8;
+        const labelY = node.y + 1;
+        const label = node.label.length > 28 ? `${node.label.slice(0, 26)}...` : node.label;
 
-        // Label text
-        ctx.fillStyle = labelText;
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(label, node.x, labelY);
+        context.font = `${isFocused ? 600 : 500} 12px "Poppins", "Segoe UI", system-ui, sans-serif`;
+        context.textAlign = "left";
+        context.textBaseline = "middle";
+        context.shadowColor = palette.labelShadow;
+        context.shadowBlur = 12;
+        context.fillStyle = palette.label;
+        context.fillText(label, labelX, labelY);
+        context.shadowBlur = 0;
 
-        // Type badge below label
-        ctx.font = `600 10px Inter, system-ui, sans-serif`;
-        ctx.fillStyle = color;
-        ctx.fillText(node.type, node.x, labelY + 16);
+        if (isFocused) {
+          context.font = `500 10px "Poppins", "Segoe UI", system-ui, sans-serif`;
+          context.fillStyle = palette.labelMuted;
+          context.fillText(node.type, labelX, labelY + 14);
+        }
       }
 
-      ctx.restore();
-      animFrameRef.current = requestAnimationFrame(render);
+      context.restore();
+      animationFrameRef.current = window.requestAnimationFrame(render);
     };
 
-    animFrameRef.current = requestAnimationFrame(render);
+    animationFrameRef.current = window.requestAnimationFrame(render);
     return () => {
-      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+      if (animationFrameRef.current) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+      }
     };
-  }, [filteredEdges, selectedNodeId, hoveredNodeId, isDark]);
+  }, [
+    effectiveRootNodeId,
+    filteredEdges,
+    hoveredNodeId,
+    impactedNodes,
+    isDark,
+    nodeNeighbors,
+    selectedNodeId,
+    showEdgeLabels,
+    showLabels,
+  ]);
 
-  // Mouse interaction
+  function resetViewport() {
+    panRef.current = { x: 0, y: 0, scale: 1, dragging: false, lastX: 0, lastY: 0 };
+    setViewScale(1);
+  }
+
+  function zoomToFit() {
+    const canvas = canvasRef.current;
+    if (!canvas || simNodesRef.current.length === 0) return;
+
+    const { width, height } = canvas.getBoundingClientRect();
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+
+    for (const node of simNodesRef.current) {
+      minX = Math.min(minX, node.x);
+      maxX = Math.max(maxX, node.x);
+      minY = Math.min(minY, node.y);
+      maxY = Math.max(maxY, node.y);
+    }
+
+    const padding = 72;
+    const graphW = maxX - minX + padding * 2;
+    const graphH = maxY - minY + padding * 2;
+    const scale = clamp(Math.min(width / graphW, height / graphH), 0.3, 2.5);
+
+    panRef.current.scale = scale;
+    panRef.current.x = width / 2 - ((minX + maxX) / 2) * scale;
+    panRef.current.y = height / 2 - ((minY + maxY) / 2) * scale;
+    setViewScale(Number(scale.toFixed(2)));
+  }
+
+  function focusNode(nodeId: string) {
+    setRootNodeId(nodeId);
+    setSelectedNodeId(nodeId);
+    setPanelOpen(true);
+    setActiveTab("info");
+    setDeleteNodeError(null);
+    resetViewport();
+  }
+
+  function handleSearchSelect(node: BrainNode) {
+    setSearchText("");
+    focusNode(node.id);
+  }
+
+  function clearBrainFilters() {
+    setSearchText("");
+    setFilterType(null);
+    setRootNodeId(null);
+    setSelectedNodeId(null);
+    setHoveredNodeId(null);
+    resetViewport();
+  }
+
+  async function sendChatMessage(question: string) {
+    if (!question.trim() || chatLoading) return;
+
+    const newMsg: ChatMessage = { id: `u-${Date.now()}`, role: "user", content: question };
+    const assistantId = `a-${Date.now() + 1}`;
+    const assistantMsg: ChatMessage = { id: assistantId, role: "assistant", content: "" };
+
+    setChatMessages((prev) => [...prev, newMsg, assistantMsg]);
+    setChatInput("");
+    setChatLoading(true);
+
+    try {
+      const res = await fetch("/api/brain/ask", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          messages: [...chatMessages, newMsg].map((m) => ({ role: m.role, content: m.content })),
+          nodeId: selectedNodeId ?? undefined,
+        }),
+      });
+
+      if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let accumulated = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        for (const line of chunk.split("\n")) {
+          // Vercel AI SDK data stream: '0:"text"' = text chunk
+          if (line.startsWith("0:")) {
+            try {
+              accumulated += JSON.parse(line.slice(2));
+              setChatMessages((prev) =>
+                prev.map((m) => (m.id === assistantId ? { ...m, content: accumulated } : m)),
+              );
+            } catch {
+              // skip malformed chunk
+            }
+          }
+        }
+      }
+    } catch {
+      setChatMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? { ...m, content: locale === "pt" ? "Erro ao obter resposta." : "Error getting response." }
+            : m,
+        ),
+      );
+    } finally {
+      setChatLoading(false);
+    }
+  }
+
+  async function handleCreateNode() {
+    if (!createNodeLabel.trim()) return;
+    setCreateNodeLoading(true);
+    setCreateNodeError(null);
+
+    try {
+      const shouldAttachToSelection = Boolean(selectedNodeId && createNodeAttachToSelection);
+      const res = await fetch("/api/brain/nodes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          type: createNodeType,
+          label: createNodeLabel.trim(),
+          description: createNodeDesc.trim() || undefined,
+        }),
+      });
+
+      if (res.ok) {
+        const { node } = await res.json();
+
+        if (shouldAttachToSelection && selectedNodeId) {
+          const edgeRes = await fetch("/api/brain/edges", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({
+              fromId: selectedNodeId,
+              toId: node.id,
+              type: createNodeLinkType,
+            }),
+          });
+
+          if (!edgeRes.ok) {
+            console.error("[brain] failed to connect new node to selection", await edgeRes.text());
+          }
+        }
+
+        setCreateNodeLabel("");
+        setCreateNodeDesc("");
+        setCreateNodeType("Note");
+        setCreateNodeLinkType("RELATES_TO");
+        await Promise.all([
+          mutateStats(),
+          mutateGraph(),
+          selectedNodeId ? mutateNodeContext() : Promise.resolve(undefined),
+          selectedNodeId ? mutateTimeline() : Promise.resolve(undefined),
+        ]);
+        focusNode(node.id);
+      } else {
+        const data = await res.json();
+        setCreateNodeError(data.error ?? "Erro ao criar n\u00f3");
+      }
+    } catch {
+      setCreateNodeError("Erro de conex\u00e3o");
+    } finally {
+      setCreateNodeLoading(false);
+    }
+  }
+
+  async function handleDeleteNode() {
+    if (!selectedNode || deleteNodeLoading) return;
+    const deletingPinnedRoot = rootNodeId === selectedNode.id;
+
+    const confirmed = window.confirm(
+      locale === "pt"
+        ? `Excluir o n\u00f3 "${selectedNode.label}" e remover as conex\u00f5es dele?`
+        : `Delete "${selectedNode.label}" and remove all of its connections?`,
+    );
+    if (!confirmed) return;
+
+    setDeleteNodeLoading(true);
+    setDeleteNodeError(null);
+
+    try {
+      const res = await fetch(`/api/brain/nodes/${selectedNode.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(
+          data?.error ??
+            (locale === "pt" ? "Erro ao excluir n\u00f3" : "Failed to delete node"),
+        );
+      }
+
+      if (deletingPinnedRoot) {
+        setRootNodeId(null);
+      }
+
+      setSelectedNodeId(null);
+      setHoveredNodeId((current) => (current === selectedNode.id ? null : current));
+      setActiveTab("info");
+      setPanelOpen(true);
+      resetViewport();
+
+      await Promise.all([
+        mutateStats(),
+        deletingPinnedRoot ? Promise.resolve(undefined) : mutateGraph(),
+      ]);
+    } catch (error) {
+      setDeleteNodeError(
+        error instanceof Error
+          ? error.message
+          : locale === "pt"
+            ? "Erro ao excluir n\u00f3"
+            : "Failed to delete node",
+      );
+    } finally {
+      setDeleteNodeLoading(false);
+    }
+  }
+
+  async function handleSync() {
+    setSyncLoading(true);
+    setSyncResult(null);
+    try {
+      const res = await fetch("/api/brain/sync", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSyncResult({ nodes: data.nodeCount ?? 0, edges: data.edgeCount ?? 0 });
+        mutateStats();
+        // Refetch graph after sync
+        setTimeout(() => setSyncResult(null), 4000);
+      }
+    } catch {
+      // silent
+    } finally {
+      setSyncLoading(false);
+    }
+  }
+
   function findNodeAtPoint(clientX: number, clientY: number) {
     const canvas = canvasRef.current;
     if (!canvas) return null;
+
     const rect = canvas.getBoundingClientRect();
     const pan = panRef.current;
     const mx = (clientX - rect.left - pan.x) / pan.scale;
     const my = (clientY - rect.top - pan.y) / pan.scale;
 
-    for (let i = simNodesRef.current.length - 1; i >= 0; i--) {
-      const node = simNodesRef.current[i];
-      const r = getNodeRadius(node.type, node.isRoot ?? false);
+    for (let index = simNodesRef.current.length - 1; index >= 0; index -= 1) {
+      const node = simNodesRef.current[index];
+      const radius = getNodeRadius(
+        node,
+        node.id === selectedNodeId || node.id === effectiveRootNodeId,
+        node.id === hoveredNodeId,
+      ) + 8;
       const dx = mx - node.x;
       const dy = my - node.y;
-      if (dx * dx + dy * dy <= (r + 4) * (r + 4)) return node;
+
+      if (dx * dx + dy * dy <= radius * radius) {
+        return node;
+      }
     }
+
     return null;
   }
 
-  function handleMouseDown(e: React.MouseEvent<HTMLCanvasElement>) {
-    const node = findNodeAtPoint(e.clientX, e.clientY);
+  function handleMouseDown(event: ReactMouseEvent<HTMLCanvasElement>) {
+    const node = findNodeAtPoint(event.clientX, event.clientY);
     if (node) {
       const canvas = canvasRef.current!;
       const rect = canvas.getBoundingClientRect();
       const pan = panRef.current;
-      const mx = (e.clientX - rect.left - pan.x) / pan.scale;
-      const my = (e.clientY - rect.top - pan.y) / pan.scale;
-      dragRef.current = { nodeId: node.id, offsetX: mx - node.x, offsetY: my - node.y };
+      const mx = (event.clientX - rect.left - pan.x) / pan.scale;
+      const my = (event.clientY - rect.top - pan.y) / pan.scale;
+
+      dragRef.current = {
+        nodeId: node.id,
+        offsetX: mx - node.x,
+        offsetY: my - node.y,
+      };
       node.fx = node.x;
       node.fy = node.y;
       return;
     }
 
     panRef.current.dragging = true;
-    panRef.current.lastX = e.clientX;
-    panRef.current.lastY = e.clientY;
+    panRef.current.lastX = event.clientX;
+    panRef.current.lastY = event.clientY;
   }
 
-  function handleMouseMove(e: React.MouseEvent<HTMLCanvasElement>) {
+  function handleMouseMove(event: ReactMouseEvent<HTMLCanvasElement>) {
     if (dragRef.current) {
       const canvas = canvasRef.current!;
       const rect = canvas.getBoundingClientRect();
       const pan = panRef.current;
-      const mx = (e.clientX - rect.left - pan.x) / pan.scale;
-      const my = (e.clientY - rect.top - pan.y) / pan.scale;
-      const node = simNodesRef.current.find((entry) => entry.id === dragRef.current!.nodeId);
+      const mx = (event.clientX - rect.left - pan.x) / pan.scale;
+      const my = (event.clientY - rect.top - pan.y) / pan.scale;
+      const node = simNodesRef.current.find((entry) => entry.id === dragRef.current?.nodeId);
+
       if (node) {
         node.fx = mx - dragRef.current.offsetX;
         node.fy = my - dragRef.current.offsetY;
         node.x = node.fx;
         node.y = node.fy;
       }
+
       return;
     }
 
     if (panRef.current.dragging) {
-      panRef.current.x += e.clientX - panRef.current.lastX;
-      panRef.current.y += e.clientY - panRef.current.lastY;
-      panRef.current.lastX = e.clientX;
-      panRef.current.lastY = e.clientY;
+      panRef.current.x += event.clientX - panRef.current.lastX;
+      panRef.current.y += event.clientY - panRef.current.lastY;
+      panRef.current.lastX = event.clientX;
+      panRef.current.lastY = event.clientY;
       return;
     }
 
-    const hoverNode = findNodeAtPoint(e.clientX, e.clientY);
-    setHoveredNodeId(hoverNode?.id ?? null);
+    const hoveredNode = findNodeAtPoint(event.clientX, event.clientY);
+    setHoveredNodeId(hoveredNode?.id ?? null);
   }
 
   function handleMouseUp() {
     if (dragRef.current) {
-      const node = simNodesRef.current.find((entry) => entry.id === dragRef.current!.nodeId);
+      const node = simNodesRef.current.find((entry) => entry.id === dragRef.current?.nodeId);
       if (node) {
         node.fx = null;
         node.fy = null;
       }
+
       setSelectedNodeId(dragRef.current.nodeId);
+      setPanelOpen(true);
       dragRef.current = null;
       return;
     }
@@ -599,142 +1432,275 @@ export default function BrainGraphView() {
     panRef.current.dragging = false;
   }
 
-  function handleWheel(e: React.WheelEvent<HTMLCanvasElement>) {
-    e.preventDefault();
+  function handleWheel(event: ReactWheelEvent<HTMLCanvasElement>) {
+    event.preventDefault();
+
     const canvas = canvasRef.current!;
     const rect = canvas.getBoundingClientRect();
-    const mx = e.clientX - rect.left;
-    const my = e.clientY - rect.top;
-
+    const mx = event.clientX - rect.left;
+    const my = event.clientY - rect.top;
+    const zoomFactor = event.deltaY > 0 ? 0.92 : 1.08;
     const pan = panRef.current;
-    const zoomFactor = e.deltaY > 0 ? 0.92 : 1.08;
-    const newScale = Math.max(0.2, Math.min(5, pan.scale * zoomFactor));
+    const nextScale = clamp(pan.scale * zoomFactor, 0.3, 4.5);
 
-    pan.x = mx - ((mx - pan.x) / pan.scale) * newScale;
-    pan.y = my - ((my - pan.y) / pan.scale) * newScale;
-    pan.scale = newScale;
-    setViewScale(Number(newScale.toFixed(2)));
+    pan.x = mx - ((mx - pan.x) / pan.scale) * nextScale;
+    pan.y = my - ((my - pan.y) / pan.scale) * nextScale;
+    pan.scale = nextScale;
+    setViewScale(Number(nextScale.toFixed(2)));
   }
 
-  function handleDoubleClick(e: React.MouseEvent<HTMLCanvasElement>) {
-    const node = findNodeAtPoint(e.clientX, e.clientY);
+  function handleDoubleClick(event: ReactMouseEvent<HTMLCanvasElement>) {
+    const node = findNodeAtPoint(event.clientX, event.clientY);
     if (node) {
-      setRootNodeId(node.id);
-      setSelectedNodeId(node.id);
-      panRef.current = { x: 0, y: 0, scale: 1, dragging: false, lastX: 0, lastY: 0 };
-      setViewScale(1);
+      focusNode(node.id);
     }
   }
 
-  function resetViewport() {
-    panRef.current = { x: 0, y: 0, scale: 1, dragging: false, lastX: 0, lastY: 0 };
-    setViewScale(1);
+  function renderNodeButton(node: BrainNode, meta?: string) {
+    return (
+      <button
+        key={node.id}
+        type="button"
+        className={styles.listButton}
+        onClick={() => focusNode(node.id)}
+      >
+        <span
+          className={styles.listButtonDot}
+          data-type={node.type}
+        />
+        <span className={styles.listButtonBody}>
+          <span className={styles.listButtonTitle}>{node.label}</span>
+          <span className={styles.listButtonMeta}>{meta ?? node.type}</span>
+        </span>
+      </button>
+    );
   }
 
-  function clearBrainFilters() {
-    setSearchText("");
-    setFilterType(null);
-    setRootNodeId(null);
-    resetViewport();
+  function renderSuggestionButton(suggestion: BrainNodeSuggestion) {
+    return (
+      <button
+        key={suggestion.suggestedNodeId}
+        type="button"
+        className={styles.listButton}
+        onClick={() => focusNode(suggestion.suggestedNode.id)}
+      >
+        <span
+          className={styles.listButtonDot}
+          data-type={suggestion.suggestedNode.type}
+        />
+        <span className={styles.listButtonBody}>
+          <span className={styles.listButtonTitle}>{suggestion.suggestedNode.label}</span>
+          <span className={styles.listButtonMeta}>
+            {suggestion.reason} / score {suggestion.score}
+          </span>
+        </span>
+      </button>
+    );
   }
-
-  // Node types present for filter buttons
-  const nodeTypes = Array.from(new Set(nodes.map((n) => n.type))).sort();
-
-  // Selected node context
-  const selectedNode = nodes.find((n) => n.id === selectedNodeId);
-  const nodeNeighbors = nodeContext?.context?.neighbors ?? [];
-  const nodeOutgoing = nodeContext?.context?.outgoing ?? [];
-  const nodeIncoming = nodeContext?.context?.incoming ?? [];
-  const isPanelVisible = panelOpen && (!!selectedNode || !!stats);
-  const recentActivity = stats?.recentActivity?.slice(0, 6) ?? [];
-  const topNodeTypes = stats?.breakdown?.nodesByType?.slice(0, 6) ?? [];
-  const impactData = nodeContext?.impact;
-  const impactedNodes = impactData?.impactedNodes ?? [];
-  const impactPaths = impactData?.paths ?? [];
 
   return (
     <div className={styles.brainPage}>
-      {/* Top bar */}
       <div className={styles.topBar}>
         <div className={styles.topBarMain}>
           <div className={styles.titleBlock}>
-            <div className={styles.title}>
-              <span className={styles.pulseOrb} />
-              {t.brain.title} - {t.brain.subtitle}
-            </div>
+            <span className={styles.kicker}>
+              {locale === "pt" ? "Mapa neural de conhecimento" : "Knowledge neural map"}
+            </span>
+            <div className={styles.title}>{t.brain.title}</div>
             <div className={styles.subtitleMeta}>
               {locale === "pt"
-                ? `Exploracao em profundidade ${depth} com ${filteredNodes.length} nos visiveis.`
-                : `Depth ${depth} exploration with ${filteredNodes.length} visible nodes.`}
+                ? "Grafo interativo com IA integrada, conex\u00f5es direcionais e explora\u00e7\u00e3o sem\u00e2ntica."
+                : "Interactive graph with integrated AI, directional connections and semantic exploration."}
             </div>
           </div>
 
           <div className={styles.controlCluster}>
-            <input
-              className={styles.searchInput}
-              placeholder={t.brain.searchPlaceholder}
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-            />
+            <div className={styles.searchShell}>
+              <input
+                className={styles.searchInput}
+                placeholder={t.brain.searchPlaceholder}
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+              />
+
+              {showSearchResults ? (
+                <div className={styles.searchResults}>
+                  {searchLoading ? (
+                    <div className={styles.searchState}>
+                      {locale === "pt" ? "Buscando no Brain..." : "Searching the Brain..."}
+                    </div>
+                  ) : (
+                    searchResults.map((node) => (
+                      <button
+                        key={node.id}
+                        type="button"
+                        className={styles.searchItem}
+                        onClick={() => handleSearchSelect(node)}
+                      >
+                        <span
+                          className={styles.searchDot}
+                          data-type={node.type}
+                        />
+                        <span className={styles.searchMeta}>
+                          <span className={styles.searchLabel}>{node.label}</span>
+                          <span className={styles.searchType}>{node.type}</span>
+                        </span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              ) : null}
+            </div>
 
             <div className={styles.depthControl}>
-              <button
-                type="button"
-                className={styles.filterBtn}
-                onClick={() => setDepth((current) => Math.max(1, current - 1))}
-                disabled={depth <= 1}
+                <button
+                  type="button"
+                  className={styles.filterBtn}
+                  onClick={() => setDepth((current) => Math.max(1, current - 1))}
+                  disabled={depth <= 1}
               >
                 -1
               </button>
               <span className={styles.depthBadge}>
                 {locale === "pt" ? `Profundidade ${depth}` : `Depth ${depth}`}
               </span>
-              <button
-                type="button"
-                className={styles.filterBtn}
-                onClick={() => setDepth((current) => Math.min(4, current + 1))}
-                disabled={depth >= 4}
-              >
-                +1
-              </button>
-            </div>
+                <button
+                  type="button"
+                  className={styles.filterBtn}
+                  onClick={() => setDepth((current) => Math.min(MAX_GRAPH_DEPTH, current + 1))}
+                  disabled={depth >= MAX_GRAPH_DEPTH}
+                >
+                  +1
+                </button>
+              </div>
 
-            <button type="button" className={styles.filterBtn} onClick={resetViewport}>
-              {`Zoom ${Math.round(viewScale * 100)}%`}
+            <button
+              type="button"
+              className={showLabels ? styles.filterBtnActive : styles.filterBtn}
+              onClick={() => setShowLabels((current) => !current)}
+              title={locale === "pt" ? "Alternar r\u00f3tulos (L)" : "Toggle labels (L)"}
+            >
+              {locale === "pt" ? "R\u00f3tulos" : "Labels"}
             </button>
 
-            <button type="button" className={styles.filterBtn} onClick={clearBrainFilters}>
-              {locale === "pt" ? "Limpar foco" : "Clear focus"}
+            <button
+              type="button"
+              className={showEdgeLabels ? styles.filterBtnActive : styles.filterBtn}
+              onClick={() => setShowEdgeLabels((current) => !current)}
+            >
+              {locale === "pt" ? "Arestas" : "Edges"}
             </button>
 
             <button
               type="button"
               className={panelOpen ? styles.filterBtnActive : styles.filterBtn}
               onClick={() => setPanelOpen((current) => !current)}
+              title={locale === "pt" ? "Alternar painel (P)" : "Toggle panel (P)"}
             >
               {locale === "pt" ? "Painel" : "Panel"}
             </button>
+
+            <button type="button" className={styles.filterBtn} onClick={clearBrainFilters}>
+              {locale === "pt" ? "Limpar" : "Clear"}
+            </button>
           </div>
+        </div>
+
+        <div className={styles.statsBar}>
+          <div className={styles.scoreCard}>
+            <span className={styles.scoreLabel}>Brain score</span>
+            <span className={styles.scoreValue}>{intelligenceScore}</span>
+            <span className={styles.scoreNote}>
+              {locale === "pt" ? "sa\u00fade estrutural e mem\u00f3ria" : "structural health and memory"}
+            </span>
+          </div>
+
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>{t.brain.stats.nodes}</span>
+            <span className={styles.statValue}>{graphMetrics?.nodeCount ?? "-"}</span>
+          </div>
+
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>{t.brain.stats.edges}</span>
+            <span className={styles.statValue}>{graphMetrics?.edgeCount ?? "-"}</span>
+          </div>
+
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>{t.brain.stats.memories}</span>
+            <span className={styles.statValue}>{graphMetrics?.memoryCount ?? "-"}</span>
+          </div>
+
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>{locale === "pt" ? "densidade" : "density"}</span>
+            <span className={styles.statValue}>
+              {graphMetrics ? graphMetrics.density.toFixed(3) : "-"}
+            </span>
+          </div>
+        </div>
+
+        {/* Workspace mode selector */}
+        <div className={styles.workspaceBar}>
+          {Object.entries(WORKSPACE_MODES).map(([key, mode]) => (
+            <button
+              key={key}
+              type="button"
+              className={workspaceMode === key ? styles.workspaceBtnActive : styles.workspaceBtn}
+              onClick={() => setWorkspaceMode(key)}
+            >
+              {locale === "pt" ? mode.label : mode.labelEn}
+            </button>
+          ))}
+          <span className={styles.workspaceSep} />
+          <button
+            type="button"
+            className={showExplorer ? styles.workspaceBtnActive : styles.workspaceBtn}
+            onClick={() => setShowExplorer((v) => !v)}
+            title="E"
+          >
+            {locale === "pt" ? "Mapa neural" : "Neural map"}
+          </button>
+          <button
+            type="button"
+            className={styles.workspaceBtn}
+            onClick={() => { setShowPalette(true); setPaletteQuery(""); }}
+            title="Ctrl+K"
+          >
+            {locale === "pt" ? "Comandos Ctrl+K" : "Commands Ctrl+K"}
+          </button>
+          <span className={styles.workspaceSep} />
+          <button
+            type="button"
+            className={syncLoading ? styles.workspaceBtnActive : styles.workspaceBtn}
+            onClick={handleSync}
+            disabled={syncLoading}
+            title={locale === "pt" ? "Sincronizar todos os n\u00f3s do sistema com o Brain" : "Sync all system entities to Brain"}
+          >
+            {syncLoading
+              ? (locale === "pt" ? "Sincronizando..." : "Syncing...")
+              : syncResult
+                ? (locale === "pt" ? `OK ${syncResult.nodes} n\u00f3s` : `OK ${syncResult.nodes} nodes`)
+                : (locale === "pt" ? "Sincronizar" : "Sync")}
+          </button>
         </div>
 
         <div className={styles.filterRow}>
           {nodeTypes.map((type) => (
             <button
               key={type}
+              type="button"
               className={filterType === type ? styles.filterBtnActive : styles.filterBtn}
-              onClick={() => setFilterType(filterType === type ? null : type)}
+              onClick={() => setFilterType((current) => (current === type ? null : type))}
+              data-type={filterType === type ? type : undefined}
             >
               <span
                 className={styles.filterDot}
-                data-color={getNodeColor(type, isDark)}
-                ref={(el) => { if (el) el.style.setProperty("--dot-color", getNodeColor(type, isDark)); }}
+                data-type={type}
               />
               {type}
             </button>
           ))}
 
-          {rootNodeId && (
+          {effectiveRootNodeId ? (
             <button
               type="button"
               className={styles.filterBtn}
@@ -743,61 +1709,143 @@ export default function BrainGraphView() {
                 resetViewport();
               }}
             >
-              {locale === "pt" ? "Resetar raiz" : "Reset root"}
+              {locale === "pt" ? "Soltar raiz" : "Release root"}
             </button>
-          )}
-        </div>
-
-        <div className={styles.statsBar}>
-          <div className={styles.statItem}>
-            <span className={styles.statValue}>{stats?.integrity?.stats?.nodes ?? "-"}</span>
-            <span className={styles.statLabel}>{t.brain.stats.nodes}</span>
-          </div>
-          <div className={styles.statItem}>
-            <span className={styles.statValue}>{stats?.integrity?.stats?.edges ?? "-"}</span>
-            <span className={styles.statLabel}>{t.brain.stats.edges}</span>
-          </div>
-          <div className={styles.statItem}>
-            <span className={styles.statValue}>{stats?.integrity?.stats?.memories ?? "-"}</span>
-            <span className={styles.statLabel}>{t.brain.stats.memories}</span>
-          </div>
-          <div className={styles.statItem}>
-            <span className={styles.statValue}>{filteredNodes.length}</span>
-            <span className={styles.statLabel}>{locale === "pt" ? "Visiveis" : "Visible"}</span>
-          </div>
+          ) : null}
         </div>
       </div>
-      {/* Main area */}
+
       <div className={styles.mainArea}>
+        <div className={styles.explorerShell}>
+          {showExplorer ? (
+            <div className={styles.explorerPanel}>
+              <div className={styles.explorerHeader}>
+                <div className={styles.explorerHeading}>
+                  <span className={styles.explorerTitle}>
+                    {locale === "pt" ? "Mapa neural" : "Neural map"}
+                  </span>
+                  <span className={styles.explorerCount}>
+                    {nodes.length} {locale === "pt" ? "n\u00f3s" : "nodes"}
+                  </span>
+                </div>
+              </div>
+              <div className={styles.explorerBody}>
+                {Array.from(nodesByType.entries())
+                  .sort((a, b) => b[1].length - a[1].length)
+                  .map(([type, typeNodes]) => {
+                    const isCollapsed = explorerCollapsed.has(type);
+                    return (
+                      <div key={type} className={styles.explorerGroup}>
+                        <button
+                          type="button"
+                          className={styles.explorerGroupHeader}
+                          onClick={() =>
+                            setExplorerCollapsed((prev) => {
+                              const next = new Set(prev);
+                              if (next.has(type)) next.delete(type);
+                              else next.add(type);
+                              return next;
+                            })
+                          }
+                        >
+                          <span
+                            className={styles.explorerGroupDot}
+                            data-type={type}
+                          />
+                          <span className={styles.explorerGroupLabel}>{type}</span>
+                          <span className={styles.explorerGroupCount}>{typeNodes.length}</span>
+                          <span className={styles.explorerGroupChevron}>
+                            {isCollapsed ? ">" : "v"}
+                          </span>
+                        </button>
+                        {!isCollapsed && (
+                          <div className={styles.explorerItems}>
+                            {typeNodes
+                              .sort((a, b) => a.label.localeCompare(b.label))
+                              .map((node) => (
+                                <button
+                                  key={node.id}
+                                  type="button"
+                                  className={
+                                    selectedNodeId === node.id
+                                      ? styles.explorerItemActive
+                                      : styles.explorerItem
+                                  }
+                                  onClick={() => focusNode(node.id)}
+                                  title={node.description ?? node.label}
+                                >
+                                  {node.label}
+                                </button>
+                              ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+          ) : null}
+
+          <div className={`${styles.sideRail} ${styles.sideRailLeft}`}>
+            <button
+              type="button"
+              className={styles.sideRailButton}
+              onClick={() => setShowExplorer((value) => !value)}
+              title={
+                showExplorer
+                  ? locale === "pt"
+                    ? "Recolher mapa neural"
+                    : "Collapse neural map"
+                  : locale === "pt"
+                    ? "Expandir mapa neural"
+                    : "Expand neural map"
+              }
+            >
+              <span className={styles.sideRailArrow}>{showExplorer ? "<" : ">"}</span>
+              <span className={styles.sideRailLabel}>{locale === "pt" ? "Mapa" : "Map"}</span>
+            </button>
+          </div>
+        </div>
+
         <div className={styles.graphContainer}>
           <div className={styles.graphHud}>
             <div className={styles.graphHudGroup}>
               <span className={styles.hudPill}>
-                {rootNodeId
-                  ? `${locale === "pt" ? "Raiz" : "Root"}: ${selectedNode?.id === rootNodeId ? selectedNode.label : rootNodeId.slice(0, 8)}`
-                  : locale === "pt" ? "Mapa global" : "Global map"}
+                {activeRootLabel
+                  ? `${locale === "pt" ? "Raiz" : "Root"}: ${activeRootLabel}`
+                  : locale === "pt"
+                    ? "C\u00e9rebro completo"
+                    : "Global graph"}
               </span>
-              <span className={styles.hudPill}>{filteredNodes.length} {locale === "pt" ? "nos" : "nodes"}</span>
-              <span className={styles.hudPill}>{filteredEdges.length} {locale === "pt" ? "conexoes" : "edges"}</span>
+              <span className={styles.hudPill}>
+                {filteredNodes.length} {locale === "pt" ? "n\u00f3s" : "nodes"}
+              </span>
+              <span className={styles.hudPill}>
+                {filteredEdges.length} {locale === "pt" ? "arestas" : "edges"}
+              </span>
             </div>
+
             <div className={styles.graphHudGroup}>
+              <button type="button" className={styles.hudButton} onClick={zoomToFit} title="F">
+                {locale === "pt" ? "Ajustar" : "Fit"}
+              </button>
               <button type="button" className={styles.hudButton} onClick={resetViewport}>
                 {locale === "pt" ? "Centralizar" : "Center"}
               </button>
-              <button type="button" className={styles.hudButton} onClick={() => setPanelOpen((current) => !current)}>
-                {panelOpen ? (locale === "pt" ? "Ocultar painel" : "Hide panel") : (locale === "pt" ? "Mostrar painel" : "Show panel")}
+              <button type="button" className={styles.hudButton}>
+                {`${Math.round(viewScale * 100)}%`}
               </button>
             </div>
           </div>
 
           {graphLoading ? (
             <div className={styles.emptyState}>
-              <div className={styles.pulseOrbLg} />
+              <div className={styles.emptyIcon} />
               <span>{t.common.loading}</span>
             </div>
           ) : filteredNodes.length === 0 ? (
-          <div className={styles.emptyState}>
-              <div className={styles.emptyIcon}>*</div>
+            <div className={styles.emptyState}>
+              <div className={styles.emptyIcon} />
               <span>{t.brain.empty.title}</span>
               <span className={styles.emptyDescription}>{t.brain.empty.description}</span>
             </div>
@@ -808,179 +1856,927 @@ export default function BrainGraphView() {
               onMouseDown={handleMouseDown}
               onMouseMove={handleMouseMove}
               onMouseUp={handleMouseUp}
-              onMouseLeave={() => { handleMouseUp(); setHoveredNodeId(null); }}
+              onMouseLeave={() => {
+                handleMouseUp();
+                setHoveredNodeId(null);
+              }}
               onWheel={handleWheel}
               onDoubleClick={handleDoubleClick}
             />
           )}
+
+          {/* Color legend by type */}
+          <div className={styles.graphLegend}>
+            <div className={styles.legendTitle}>
+              {locale === "pt" ? "Tipos de n\u00f3" : "Node types"}
+            </div>
+            {NODE_TYPES.filter((type) => nodeTypes.includes(type)).map((type) => (
+              <div key={type} className={styles.legendRow}>
+                <span
+                  className={styles.legendSwatchType}
+                  data-type={type}
+                />
+                <span className={styles.legendLabel}>{type}</span>
+              </div>
+            ))}
+            <div className={styles.legendRow}>
+              <span className={styles.legendSwatchFocus} />
+              <span className={styles.legendLabel}>
+                {locale === "pt" ? "foco atual" : "active focus"}
+              </span>
+            </div>
+            <div className={styles.legendSeparator} />
+            <div className={styles.legendShortcuts}>
+              <span>F: fit</span>
+              <span>L: labels</span>
+              <span>{locale === "pt" ? "E: mapa" : "E: explorer"}</span>
+              <span>{locale === "pt" ? "Ctrl+K: comandos" : "Ctrl+K: palette"}</span>
+              <span>{locale === "pt" ? "Esc: limpar" : "Esc: clear"}</span>
+            </div>
+          </div>
         </div>
 
-        <div className={isPanelVisible ? styles.sidePanel : styles.sidePanelHidden}>
-          <div className={styles.panelHeader}>
-            <div>
-              <h2 className={styles.panelTitle}>{selectedNode ? selectedNode.label : (locale === "pt" ? "Visao do Brain" : "Brain overview")}</h2>
-              <p className={styles.panelSubtitle}>
-                {selectedNode
-                  ? `${selectedNode.type}${selectedNode.refId ? ` - ${selectedNode.refId.slice(0, 8)}` : ""}`
-                  : (locale === "pt" ? "Contexto, profundidade e atividade recente." : "Context, depth and recent activity.")}
-              </p>
-            </div>
-            <button type="button" className={styles.panelCloseBtn} onClick={() => setPanelOpen(false)}>
-              {locale === "pt" ? "Fechar" : "Close"}
+        <div className={styles.panelShell}>
+          <div className={`${styles.sideRail} ${styles.sideRailRight}`}>
+            <button
+              type="button"
+              className={styles.sideRailButton}
+              onClick={() => setPanelOpen((value) => !value)}
+              title={
+                isPanelVisible
+                  ? locale === "pt"
+                    ? "Recolher detalhes"
+                    : "Collapse details"
+                  : locale === "pt"
+                    ? "Expandir detalhes"
+                    : "Expand details"
+              }
+            >
+              <span className={styles.sideRailArrow}>{isPanelVisible ? ">" : "<"}</span>
+              <span className={styles.sideRailLabel}>{locale === "pt" ? "Detalhes" : "Details"}</span>
             </button>
           </div>
 
-          {!selectedNode ? (
-            <>
-              <div className={styles.panelSection}>
-                <p className={styles.panelSectionTitle}>{locale === "pt" ? "Estado atual" : "Current state"}</p>
-                <div className={styles.metadataItem}>
-                  <span className={styles.metadataKey}>{locale === "pt" ? "Profundidade" : "Depth"}</span>
-                  <span className={styles.metadataValue}>{depth}</span>
-                </div>
-                <div className={styles.metadataItem}>
-                  <span className={styles.metadataKey}>{locale === "pt" ? "Zoom" : "Zoom"}</span>
-                  <span className={styles.metadataValue}>{Math.round(viewScale * 100)}%</span>
-                </div>
-                <div className={styles.metadataItem}>
-                  <span className={styles.metadataKey}>{locale === "pt" ? "Raiz" : "Root"}</span>
-                  <span className={styles.metadataValue}>{rootNodeId ? rootNodeId.slice(0, 8) : (locale === "pt" ? "Global" : "Global")}</span>
-                </div>
-                <div className={styles.metadataItem}>
-                  <span className={styles.metadataKey}>{locale === "pt" ? "Filtro" : "Filter"}</span>
-                  <span className={styles.metadataValue}>{filterType ?? (locale === "pt" ? "Todos" : "All")}</span>
-                </div>
+          <div className={isPanelVisible ? styles.sidePanel : styles.sidePanelHidden}>
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitleWrap}>
+              <h2 className={styles.panelTitle}>
+                {selectedNode
+                  ? selectedNode.label
+                  : locale === "pt"
+                    ? "Panorama neural"
+                    : "Neural overview"}
+              </h2>
+              <p className={styles.panelSubtitle}>
+                {selectedNode
+                  ? `${selectedNode.type}${selectedNode.refId ? ` / ${selectedNode.refId.slice(0, 8)}` : ""}`
+                  : locale === "pt"
+                    ? "M\u00e9tricas, sa\u00fade e m\u00f3dulos mais conectados do c\u00e9rebro."
+                    : "Metrics, health and the most connected system modules."}
+              </p>
+            </div>
+
+            <button
+              type="button"
+              className={styles.panelCloseBtn}
+              onClick={() => setPanelOpen(false)}
+              title={locale === "pt" ? "Recolher detalhes" : "Collapse details"}
+            >
+              {locale === "pt" ? "Recolher" : "Collapse"}
+            </button>
+          </div>
+
+          {/* Tab navigation */}
+          <div className={styles.panelTabs}>
+            <button
+              type="button"
+              className={activeTab === "info" ? styles.panelTabActive : styles.panelTab}
+              onClick={() => setActiveTab("info")}
+            >
+              {locale === "pt" ? "Contexto" : "Context"}
+            </button>
+            <button
+              type="button"
+              className={activeTab === "ask" ? styles.panelTabActive : styles.panelTab}
+              onClick={() => setActiveTab("ask")}
+            >
+              {locale === "pt" ? "Perguntar \u00e0 IA" : "Ask AI"}
+            </button>
+            {selectedNodeId ? (
+              <button
+                type="button"
+                className={activeTab === "timeline" ? styles.panelTabActive : styles.panelTab}
+                onClick={() => setActiveTab("timeline")}
+              >
+                {locale === "pt" ? "Hist\u00f3rico" : "Timeline"}
+                {nodeTimeline.length > 0 ? (
+                  <span className={styles.tabBadge}>{nodeTimeline.length}</span>
+                ) : null}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className={activeTab === "create" ? styles.panelTabActive : styles.panelTab}
+              onClick={() => setActiveTab("create")}
+            >
+              + {locale === "pt" ? "N\u00f3" : "Node"}
+            </button>
+          </div>
+
+          {/* Ask AI tab */}
+          {activeTab === "ask" ? (
+            <div className={styles.chatPanel}>
+              <div className={styles.chatContext}>
+                {selectedNode ? (
+                  <span className={styles.chatContextBadge}>
+                    {locale === "pt" ? "Contexto" : "Context"}: {selectedNode.label} ({selectedNode.type})
+                  </span>
+                ) : (
+                  <span className={styles.chatContextBadge}>
+                    {locale === "pt" ? "Contexto: c\u00e9rebro completo" : "Context: global graph"} | {graphMetrics?.nodeCount ?? 0} {locale === "pt" ? "n\u00f3s" : "nodes"}
+                  </span>
+                )}
+                {chatMessages.length > 0 ? (
+                  <button
+                    type="button"
+                    className={styles.chatClearBtn}
+                    onClick={() => setChatMessages([])}
+                  >
+                    {locale === "pt" ? "Limpar" : "Clear"}
+                  </button>
+                ) : null}
               </div>
 
-              {topNodeTypes.length > 0 ? (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>{locale === "pt" ? "Tipos dominantes" : "Top node types"}</p>
-                  {topNodeTypes.map((item) => (
-                    <div key={item.type} className={styles.metadataItem}>
-                      <span className={styles.metadataKey}>{item.type}</span>
-                      <span className={styles.metadataValue}>{item.count}</span>
+              <div className={styles.chatMessages} ref={chatContainerRef}>
+                {chatMessages.length === 0 ? (
+                  <div className={styles.chatEmpty}>
+                    <p className={styles.chatEmptyTitle}>
+                      {locale === "pt" ? "Pergunte ao Brain" : "Ask the Brain"}
+                    </p>
+                    <p className={styles.chatEmptyMeta}>
+                      {locale === "pt"
+                        ? "A IA usa o grafo de conhecimento como contexto para responder."
+                        : "AI uses the knowledge graph as context to answer."}
+                    </p>
+                    <div className={styles.chatSuggestions}>
+                      {(locale === "pt"
+                        ? [
+                            "Quais n\u00f3s t\u00eam mais conex\u00f5es?",
+                            "Quais defeitos afetam este m\u00f3dulo?",
+                            "Sugira conex\u00f5es que est\u00e3o faltando",
+                            "Qual \u00e9 a sa\u00fade geral do grafo?",
+                          ]
+                        : [
+                            "Which nodes have the most connections?",
+                            "What defects affect this module?",
+                            "Suggest missing connections",
+                            "What is the overall graph health?",
+                          ]
+                      ).map((suggestion) => (
+                        <button
+                          key={suggestion}
+                          type="button"
+                          className={styles.chatSuggestionBtn}
+                          onClick={() => sendChatMessage(suggestion)}
+                        >
+                          {suggestion}
+                        </button>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              ) : null}
-
-              {recentActivity.length > 0 ? (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>{locale === "pt" ? "Atividade recente" : "Recent activity"}</p>
-                  {recentActivity.map((activity) => (
-                    <div key={activity.id} className={styles.memoryCard}>
-                      <p className={styles.memoryTitle}>{activity.action}</p>
-                      <p className={styles.memorySummary}>{activity.reason ?? activity.entityType}</p>
-                      <span className={styles.memoryBadgeDynamic}>{new Date(activity.createdAt).toLocaleString(locale === "pt" ? "pt-BR" : "en-US")}</span>
+                  </div>
+                ) : (
+                  chatMessages.map((msg) => (
+                    <div
+                      key={msg.id}
+                      className={msg.role === "user" ? styles.chatMsgUser : styles.chatMsgAssistant}
+                    >
+                      <span className={styles.chatMsgRole}>
+                        {msg.role === "user"
+                          ? locale === "pt" ? "Voc\u00ea" : "You"
+                          : "Brain AI"}
+                      </span>
+                      <p className={styles.chatMsgContent}>
+                        {typeof msg.content === "string" ? msg.content : ""}
+                      </p>
                     </div>
-                  ))}
-                </div>
-              ) : null}
-            </>
-          ) : (
-            <>
-              {selectedNode.description && (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>{locale === "pt" ? "Descricao" : "Description"}</p>
-                  <p className={styles.memorySummary}>{selectedNode.description}</p>
-                </div>
-              )}
+                  ))
+                )}
+                {chatLoading ? (
+                  <div className={styles.chatLoading}>
+                    <span className={styles.chatLoadingDot} />
+                    <span className={styles.chatLoadingDot} />
+                    <span className={styles.chatLoadingDot} />
+                  </div>
+                ) : null}
+              </div>
 
-              {selectedNode.metadata && Object.keys(selectedNode.metadata).length > 0 && (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>{locale === "pt" ? "Metadados" : "Metadata"}</p>
-                  {Object.entries(selectedNode.metadata).map(([key, val]) => (
-                    <div key={key} className={styles.metadataItem}>
-                      <span className={styles.metadataKey}>{key}</span>
-                      <span className={styles.metadataValue}>{String(val)}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {nodeNeighbors.length > 0 && (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>
-                    {t.brain.panel.connections} ({nodeOutgoing.length} {locale === "pt" ? "saida" : "out"}, {nodeIncoming.length} {locale === "pt" ? "entrada" : "in"})
+              <form
+                className={styles.chatForm}
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  sendChatMessage(chatInput);
+                }}
+              >
+                <input
+                  className={styles.chatInput}
+                  value={chatInput}
+                  onChange={(e) => setChatInput(e.target.value)}
+                  placeholder={
+                    locale === "pt"
+                      ? "Pergunte sobre o grafo..."
+                      : "Ask about the graph..."
+                  }
+                  disabled={chatLoading}
+                />
+                <button
+                  type="submit"
+                  className={styles.chatSendBtn}
+                  disabled={chatLoading || !chatInput.trim()}
+                >
+                  {locale === "pt" ? "Enviar" : "Send"}
+                </button>
+              </form>
+            </div>
+          ) : activeTab === "timeline" ? (
+            /* Timeline tab */
+            <div className={styles.timelinePanel}>
+              <div className={styles.panelSection}>
+                <p className={styles.panelSectionTitle}>
+                  {locale === "pt" ? "Linha do tempo" : "Timeline"}
+                  {selectedNode ? ` - ${selectedNode.label}` : ""}
+                </p>
+                {nodeTimeline.length === 0 ? (
+                  <p className={styles.panelHeroMeta}>
+                    {locale === "pt"
+                      ? "Nenhum registro de auditoria para este n\u00f3."
+                      : "No audit records for this node."}
                   </p>
-                  {nodeNeighbors.slice(0, 20).map((neighbor: BrainNode & { id: string; label: string; type: string }) => {
-                    const outEdge = nodeOutgoing.find((e: { toId: string; type: string }) => e.toId === neighbor.id);
-                    const inEdge = nodeIncoming.find((e: { fromId: string; type: string }) => e.fromId === neighbor.id);
-                    const edgeType = outEdge?.type ?? inEdge?.type ?? "";
-
-                    return (
-                      <div key={neighbor.id} className={styles.neighborItem} onClick={() => setSelectedNodeId(neighbor.id)}>
-                        <span className={styles.neighborDot} ref={(el) => { if (el) el.style.setProperty("--dot-color", getNodeColor(neighbor.type, isDark)); }} />
-                        <span>{neighbor.label}</span>
-                        <span className={styles.neighborEdgeType}>{edgeType}</span>
+                ) : (
+                  <div className={styles.timelineList}>
+                    {nodeTimeline.map((entry) => (
+                      <div key={entry.id} className={styles.timelineItem}>
+                        <div className={styles.timelineDotWrap}>
+                          <span className={styles.timelineDot} />
+                          <span className={styles.timelineLine} />
+                        </div>
+                        <div className={styles.timelineContent}>
+                          <p className={styles.timelineAction}>{entry.action}</p>
+                          {entry.reason ? (
+                            <p className={styles.timelineReason}>{entry.reason}</p>
+                          ) : null}
+                          <span className={styles.timelineDate}>
+                            {formatDate(entry.timestamp, locale)}
+                          </span>
+                        </div>
                       </div>
-                    );
-                  })}
-                </div>
-              )}
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : activeTab === "create" ? (
+            /* Create node tab */
+            <div className={styles.createPanel}>
+              <div className={styles.panelSection}>
+                <p className={styles.panelSectionTitle}>
+                  {locale === "pt" ? "Criar novo n\u00f3" : "Create new node"}
+                </p>
+                {selectedNode ? (
+                  <p className={styles.createHint}>
+                    {locale === "pt"
+                      ? `Novo n\u00f3 a partir de ${selectedNode.label}.`
+                      : `New node starting from ${selectedNode.label}.`}
+                  </p>
+                ) : (
+                  <p className={styles.createHint}>
+                    {locale === "pt"
+                      ? "Crie um m\u00f3dulo novo e depois fixe-o no mapa."
+                      : "Create a new module and then pin it in the map."}
+                  </p>
+                )}
 
-              {memories.length > 0 && (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>{t.brain.panel.memories} ({memories.length})</p>
-                  {memories.map((m) => (
-                    <div key={m.id} className={styles.memoryCard}>
-                      <p className={styles.memoryTitle}>{m.title}</p>
-                      <p className={styles.memorySummary}>{m.summary}</p>
+                <div className={styles.createForm}>
+                  <label className={styles.createLabel}>
+                    {locale === "pt" ? "Tipo" : "Type"}
+                    <select
+                      className={styles.createSelect}
+                      value={createNodeType}
+                      onChange={(e) => setCreateNodeType(e.target.value)}
+                    >
+                      {NODE_TYPES.map((type) => (
+                        <option key={type} value={type}>{type}</option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className={styles.createLabel}>
+                    {locale === "pt" ? "Nome / Label" : "Name / Label"}
+                    <input
+                      className={styles.createInput}
+                      value={createNodeLabel}
+                      onChange={(e) => setCreateNodeLabel(e.target.value)}
+                      placeholder={locale === "pt" ? "Nome do n\u00f3..." : "Node name..."}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleCreateNode();
+                      }}
+                    />
+                  </label>
+
+                  <label className={styles.createLabel}>
+                    {locale === "pt" ? "Descri\u00e7\u00e3o (opcional)" : "Description (optional)"}
+                    <textarea
+                      className={styles.createTextarea}
+                      value={createNodeDesc}
+                      onChange={(e) => setCreateNodeDesc(e.target.value)}
+                      placeholder={locale === "pt" ? "Descreva o n\u00f3..." : "Describe the node..."}
+                      rows={3}
+                    />
+                  </label>
+
+                  {selectedNode ? (
+                    <>
+                      <label className={styles.createToggle}>
+                        <input
+                          type="checkbox"
+                          checked={createNodeAttachToSelection}
+                          onChange={(e) => setCreateNodeAttachToSelection(e.target.checked)}
+                        />
+                        <span className={styles.createToggleText}>
+                          {locale === "pt"
+                            ? `Conectar ao n\u00f3 selecionado: ${selectedNode.label}`
+                            : `Connect to selected node: ${selectedNode.label}`}
+                        </span>
+                      </label>
+
+                      {createNodeAttachToSelection ? (
+                        <label className={styles.createLabel}>
+                          {locale === "pt" ? "Tipo de conex\u00e3o" : "Connection type"}
+                          <select
+                            className={styles.createSelect}
+                            value={createNodeLinkType}
+                            onChange={(e) => setCreateNodeLinkType(e.target.value)}
+                          >
+                            {CREATE_EDGE_TYPES.map((edgeType) => (
+                              <option key={edgeType.value} value={edgeType.value}>
+                                {locale === "pt" ? edgeType.labelPt : edgeType.labelEn}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      ) : null}
+                    </>
+                  ) : null}
+
+                  {createNodeError ? (
+                    <p className={styles.createError}>{createNodeError}</p>
+                  ) : null}
+
+                  <div className={styles.createPreview}>
+                    <span
+                      className={styles.createPreviewDot}
+                      data-type={createNodeType}
+                    />
+                    <span>{createNodeLabel || (locale === "pt" ? "Pr\u00e9via do n\u00f3" : "Node preview")}</span>
+                    <span className={styles.createPreviewType}>{createNodeType}</span>
+                  </div>
+
+                  <button
+                    type="button"
+                    className={styles.createSubmitBtn}
+                    onClick={handleCreateNode}
+                    disabled={createNodeLoading || !createNodeLabel.trim()}
+                  >
+                    {createNodeLoading
+                      ? (locale === "pt" ? "Criando..." : "Creating...")
+                      : (locale === "pt" ? "Criar n\u00f3" : "Create node")}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : (
+            /* Info tab */
+            <>
+              {!selectedNode ? (
+                <>
+                  <div className={`${styles.panelSection} ${styles.panelSectionHero}`}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Sinal principal" : "Primary signal"}
+                    </p>
+                    <div className={styles.panelHeroValue}>{intelligenceScore}</div>
+                    <div className={styles.panelHeroMeta}>
+                      {locale === "pt"
+                        ? "score sint\u00e9tico do Brain, combinando densidade, ciclos, mem\u00f3ria e conectividade"
+                        : "synthetic Brain score combining density, cycles, memory and connectivity"}
+                    </div>
+                    <div className={styles.metricGrid}>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>
+                          {locale === "pt" ? "grau m\u00e9dio" : "avg degree"}
+                        </span>
+                        <span className={styles.metricValue}>
+                          {graphMetrics?.averageDegree ?? "-"}
+                        </span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>
+                          {locale === "pt" ? "maior componente" : "largest component"}
+                        </span>
+                        <span className={styles.metricValue}>
+                          {graphMetrics?.largestComponent ?? "-"}
+                        </span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>
+                          {locale === "pt" ? "ciclos" : "cycles"}
+                        </span>
+                        <span className={styles.metricValue}>
+                          {graphMetrics?.cyclesDetected ?? "-"}
+                        </span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>
+                          {locale === "pt" ? "n\u00f3s \u00f3rf\u00e3os" : "orphan nodes"}
+                        </span>
+                        <span className={styles.metricValue}>
+                          {graphMetrics?.orphanedNodes ?? "-"}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className={styles.panelSection}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Alertas e leitura" : "Alerts and reading"}
+                    </p>
+                    {alerts.length > 0 ? (
+                      <div className={styles.alertList}>
+                        {alerts.map((alert) => (
+                          <div key={alert} className={styles.alertItem}>
+                            <span className={styles.alertDot} />
+                            <span>{alert}</span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className={styles.panelHeroMeta}>
+                        {locale === "pt"
+                          ? "Sem alertas estruturais no momento. O grafo est\u00e1 est\u00e1vel."
+                          : "No structural alerts right now. The graph is stable."}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className={styles.panelSection}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Hubs principais" : "Top hubs"}
+                    </p>
+                    <div className={styles.nodeList}>
+                      {topConnectedNodes.map((node) => (
+                        <button
+                          key={node.id}
+                          type="button"
+                          className={styles.listButton}
+                          onClick={() => focusNode(node.id)}
+                        >
+                          <span
+                            className={styles.listButtonDot}
+                            data-type={node.type}
+                          />
+                          <span className={styles.listButtonBody}>
+                            <span className={styles.listButtonTitle}>{node.label}</span>
+                            <span className={styles.listButtonMeta}>
+                              {node.type} / {node.totalDegree} {locale === "pt" ? "conex\u00f5es" : "connections"}
+                            </span>
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className={styles.panelSection}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Tipos dominantes" : "Top node types"}
+                    </p>
+                    <div className={styles.metadataList}>
+                      {topNodeTypes.map((item) => (
+                        <div key={item.type} className={styles.metadataItem}>
+                          <span className={styles.metadataKey}>
+                            <span
+                              className={styles.filterDot}
+                              data-type={item.type}
+                            />
+                            {item.type}
+                          </span>
+                          <span className={styles.metadataValue}>{item.count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className={styles.panelSection}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Atividade recente" : "Recent activity"}
+                    </p>
+                    <div className={styles.nodeList}>
+                      {recentActivity.map((activity) => (
+                        <div key={activity.id} className={styles.memoryCard}>
+                          <p className={styles.memoryTitle}>{activity.action}</p>
+                          <p className={styles.memorySummary}>
+                            {activity.reason ?? activity.entityType}
+                          </p>
+                          <span className={styles.memoryBadgeDynamic}>
+                            {formatDate(activity.createdAt, locale)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className={`${styles.panelSection} ${styles.panelSectionHero}`}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Pulso do n\u00f3" : "Node pulse"}
+                    </p>
+                    <div className={styles.pillRow}>
                       <span
-                        className={styles.memoryBadgeDynamic}
-                        ref={(el) => {
-                          if (el) {
-                            const c = getMemoryTypeColor(m.memoryType, isDark);
-                            el.style.setProperty("--badge-bg", c + "20");
-                            el.style.setProperty("--badge-color", c);
-                          }
+                        className={styles.pill}
+                        data-node-type={selectedNode.type}
+                      >
+                        {selectedNode.type}
+                      </span>
+                      {selectedNode.refType ? (
+                        <span className={styles.pillMuted}>{selectedNode.refType}</span>
+                      ) : null}
+                    </div>
+                    <div className={styles.metricGrid}>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "entrada" : "incoming"}</span>
+                        <span className={styles.metricValue}>{nodeContext?.stats?.inDegree ?? 0}</span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "sa\u00edda" : "outgoing"}</span>
+                        <span className={styles.metricValue}>{nodeContext?.stats?.outDegree ?? 0}</span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "mem\u00f3rias" : "memories"}</span>
+                        <span className={styles.metricValue}>{relatedMemories.length}</span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "influ\u00eancia" : "influence"}</span>
+                        <span className={styles.metricValue}>
+                          {nodeContext?.influence?.influenceScore != null
+                            ? `${nodeContext.influence.influenceScore.toFixed(1)}%`
+                            : "-"}
+                        </span>
+                      </div>
+                    </div>
+                    <div className={styles.panelHeroMeta}>
+                      {locale === "pt"
+                        ? `Import\u00e2ncia estrutural ${Math.round((nodeContext?.stats?.importance ?? 0) * 100)} / ranking ${nodeContext?.influence?.rankedPosition ?? "-"}`
+                        : `Structural importance ${Math.round((nodeContext?.stats?.importance ?? 0) * 100)} / rank ${nodeContext?.influence?.rankedPosition ?? "-"}`}
+                    </div>
+                    <div className={styles.panelActionRow}>
+                      <button
+                        type="button"
+                        className={styles.panelActionBtn}
+                        onClick={() => {
+                          setCreateNodeAttachToSelection(true);
+                          setActiveTab("create");
                         }}
                       >
-                        {m.memoryType} - I{m.importance}
-                      </span>
+                        {locale === "pt" ? "Adicionar n\u00f3 ligado" : "Add linked node"}
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.panelActionBtn}
+                        onClick={() => {
+                          setRootNodeId(selectedNode.id);
+                          resetViewport();
+                        }}
+                      >
+                        {locale === "pt" ? "Fixar como raiz" : "Pin as root"}
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.panelActionBtnDanger}
+                        onClick={handleDeleteNode}
+                        disabled={deleteNodeLoading}
+                      >
+                        {deleteNodeLoading
+                          ? locale === "pt"
+                            ? "Excluindo..."
+                            : "Deleting..."
+                          : locale === "pt"
+                            ? "Excluir n\u00f3"
+                            : "Delete node"}
+                      </button>
                     </div>
-                  ))}
-                </div>
-              )}
+                    {deleteNodeError ? (
+                      <p className={styles.inlineError}>{deleteNodeError}</p>
+                    ) : null}
+                  </div>
 
-              {impactedNodes.length > 0 && (
-                <div className={styles.panelSection}>
-                  <p className={styles.panelSectionTitle}>
-                    {locale === "pt" ? "Impacto" : "Impact"} ({impactedNodes.length} {locale === "pt" ? "nos afetados" : "affected nodes"})
-                  </p>
-                  {impactPaths.slice(0, 10).map((p: { nodeId: string; edgeType: string; distance: number }, i: number) => {
-                    const impactNode = impactedNodes.find((n: BrainNode) => n.id === p.nodeId);
-                    return (
-                      <div key={i} className={styles.neighborItem} onClick={() => setSelectedNodeId(p.nodeId)}>
-                        <span className={styles.neighborDot} ref={(el) => { if (el) el.style.setProperty("--dot-color", getNodeColor(impactNode?.type ?? "", isDark)); }} />
-                        <span>{impactNode?.label ?? p.nodeId.slice(0, 8)}</span>
-                        <span className={styles.neighborEdgeType}>{p.edgeType} (d {p.distance})</span>
+                  {selectedNode.description ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "Descri\u00e7\u00e3o" : "Description"}
+                      </p>
+                      <p className={styles.memorySummary}>{selectedNode.description}</p>
+                    </div>
+                  ) : null}
+
+                  <div className={styles.panelSection}>
+                    <p className={styles.panelSectionTitle}>
+                      {locale === "pt" ? "Linha do contexto" : "Context line"}
+                    </p>
+                    <div className={styles.metricGrid}>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "ancestrais" : "ancestors"}</span>
+                        <span className={styles.metricValue}>{ancestors.length}</span>
                       </div>
-                    );
-                  })}
-                </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "descendentes" : "descendants"}</span>
+                        <span className={styles.metricValue}>{descendants.length}</span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "impacto" : "impact"}</span>
+                        <span className={styles.metricValue}>{impactedNodes.length}</span>
+                      </div>
+                      <div className={styles.metricCell}>
+                        <span className={styles.metricName}>{locale === "pt" ? "criado" : "created"}</span>
+                        <span className={styles.metricValue}>
+                          {formatDate(nodeContext?.stats?.createdAt, locale)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {suggestions.length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "Conex\u00f5es sugeridas" : "Suggested links"}
+                      </p>
+                      <div className={styles.nodeList}>
+                        {suggestions.slice(0, 6).map(renderSuggestionButton)}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {nodeNeighbors.length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {t.brain.panel.connections} ({nodeOutgoing.length} {locale === "pt" ? "sa\u00edda" : "out"}, {nodeIncoming.length} {locale === "pt" ? "entrada" : "in"})
+                      </p>
+                      <div className={styles.nodeList}>
+                        {nodeNeighbors.slice(0, 16).map((neighbor) => {
+                          const outEdge = nodeOutgoing.find((edge) => edge.toId === neighbor.id);
+                          const inEdge = nodeIncoming.find((edge) => edge.fromId === neighbor.id);
+                          const edgeType = outEdge?.type ?? inEdge?.type ?? neighbor.type;
+                          return renderNodeButton(neighbor, edgeType);
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {relatedMemories.length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "Mem\u00f3ria conectada" : "Connected memory"} ({relatedMemories.length})
+                      </p>
+                      <div className={styles.nodeList}>
+                        {relatedMemories.slice(0, 8).map((memory) => {
+                          return (
+                            <div key={memory.id} className={styles.memoryCard}>
+                              <p className={styles.memoryTitle}>{memory.title}</p>
+                              <p className={styles.memorySummary}>{memory.summary}</p>
+                              <span
+                                className={styles.memoryBadgeDynamic}
+                                data-memory-type={memory.memoryType}
+                              >
+                                {memory.memoryType} / I{memory.importance}
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {similarNodes.length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "N\u00f3s similares" : "Similar nodes"}
+                      </p>
+                      <div className={styles.nodeList}>
+                        {similarNodes.slice(0, 6).map((node) => renderNodeButton(node))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {impactedNodes.length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "Impacto observado" : "Observed impact"} ({impactedNodes.length})
+                      </p>
+                      <div className={styles.nodeList}>
+                        {impactPaths.slice(0, 8).map((path) => {
+                          const impactedNode = impactedNodes.find((node) => node.id === path.nodeId);
+                          if (!impactedNode) return null;
+                          return renderNodeButton(
+                            impactedNode,
+                            `${path.edgeType} / d${path.distance}`,
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {ancestors.length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "Origem e contexto" : "Origin and context"}
+                      </p>
+                      <div className={styles.nodeList}>
+                        {ancestors.slice(0, 6).map((node) =>
+                          renderNodeButton(node, locale === "pt" ? "ancestral" : "ancestor"),
+                        )}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {selectedNode.metadata && Object.keys(selectedNode.metadata).length > 0 ? (
+                    <div className={styles.panelSection}>
+                      <p className={styles.panelSectionTitle}>
+                        {locale === "pt" ? "Metadados" : "Metadata"}
+                      </p>
+                      <div className={styles.metadataList}>
+                        {Object.entries(selectedNode.metadata).map(([key, value]) => (
+                          <div key={key} className={styles.metadataItem}>
+                            <span className={styles.metadataKey}>{key}</span>
+                            <span className={styles.metadataValue}>{String(value)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </>
               )}
             </>
           )}
         </div>
-      </div>
-      {/* Legend */}
-      <div className={styles.legend}>
-        {Object.entries(isDark ? NODE_COLORS_DARK : NODE_COLORS_LIGHT).map(([type, color]) => (
-          <div key={type} className={styles.legendItem}>
-            <span className={styles.legendDot} ref={(el) => { if (el) el.style.setProperty("--dot-color", color); }} />
-            {type}
-          </div>
-        ))}
-        <div className={styles.legendHint}>
-          {locale === "pt"
-            ? "Clique = selecionar | Duplo clique = explorar | Scroll = zoom | Arrastar = mover"
-            : "Click = select | Double click = explore | Scroll = zoom | Drag = move"
-          }
         </div>
       </div>
+
+      {/* Command Palette Overlay */}
+      {showPalette ? (
+        <div
+          className={styles.paletteOverlay}
+          onClick={() => setShowPalette(false)}
+          role="dialog"
+          aria-modal
+        >
+          <div
+            className={styles.paletteModal}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              ref={paletteInputRef}
+              className={styles.paletteInput}
+              placeholder={
+                locale === "pt"
+                  ? "Buscar n\u00f3s, digitar comandos..."
+                  : "Search nodes or type commands..."
+              }
+              value={paletteQuery}
+              onChange={(e) => setPaletteQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setShowPalette(false);
+              }}
+            />
+
+            <div className={styles.paletteResults}>
+              {/* Commands */}
+              {(paletteQuery === "" || "criar n\u00f3 create node".includes(paletteQuery.toLowerCase())) ? (
+                <div className={styles.paletteSection}>
+                  <span className={styles.paletteSectionTitle}>
+                    {locale === "pt" ? "Comandos" : "Commands"}
+                  </span>
+                  {[
+                    {
+                      id: "create",
+                      label: locale === "pt" ? "Criar novo n\u00f3" : "Create new node",
+                      shortcut: "C",
+                      action: () => { setActiveTab("create"); setPanelOpen(true); },
+                    },
+                    {
+                      id: "fit",
+                      label: locale === "pt" ? "Zoom to fit" : "Zoom to fit",
+                      shortcut: "F",
+                      action: () => zoomToFit(),
+                    },
+                    {
+                      id: "labels",
+                      label: locale === "pt" ? "Alternar r\u00f3tulos" : "Toggle labels",
+                      shortcut: "L",
+                      action: () => setShowLabels((v) => !v),
+                    },
+                    {
+                      id: "explorer",
+                      label: locale === "pt" ? "Alternar mapa neural" : "Toggle neural map",
+                      shortcut: "E",
+                      action: () => setShowExplorer((v) => !v),
+                    },
+                    {
+                      id: "clear",
+                      label: locale === "pt" ? "Limpar sele\u00e7\u00e3o" : "Clear selection",
+                      shortcut: "Esc",
+                      action: () => clearBrainFilters(),
+                    },
+                  ]
+                    .filter((cmd) =>
+                      paletteQuery === "" ||
+                      cmd.label.toLowerCase().includes(paletteQuery.toLowerCase()),
+                    )
+                    .map((cmd) => (
+                      <button
+                        key={cmd.id}
+                        type="button"
+                        className={styles.paletteItem}
+                        onClick={() => { cmd.action(); setShowPalette(false); }}
+                      >
+                        <span className={styles.paletteItemIcon}>K</span>
+                        <span className={styles.paletteItemLabel}>{cmd.label}</span>
+                        <span className={styles.paletteItemShortcut}>{cmd.shortcut}</span>
+                      </button>
+                    ))}
+                </div>
+              ) : null}
+
+              {/* Workspace shortcuts */}
+              {paletteQuery === "" ? (
+                <div className={styles.paletteSection}>
+                  <span className={styles.paletteSectionTitle}>
+                    {locale === "pt" ? "Workspaces" : "Workspaces"}
+                  </span>
+                  {Object.entries(WORKSPACE_MODES).map(([key, mode]) => (
+                    <button
+                      key={key}
+                      type="button"
+                      className={`${styles.paletteItem} ${workspaceMode === key ? styles.paletteItemActive : ""}`}
+                      onClick={() => { setWorkspaceMode(key); setShowPalette(false); }}
+                    >
+                      <span className={styles.paletteItemIcon}>*</span>
+                      <span className={styles.paletteItemLabel}>
+                        {locale === "pt" ? mode.label : mode.labelEn}
+                      </span>
+                      {workspaceMode === key ? (
+                        <span className={styles.paletteItemShortcut}>OK ativo</span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              {/* Node search results */}
+              {paletteNodes.length > 0 ? (
+                <div className={styles.paletteSection}>
+                  <span className={styles.paletteSectionTitle}>
+                    {locale === "pt" ? "N\u00f3s" : "Nodes"}
+                  </span>
+                  {paletteNodes.map((node) => (
+                    <button
+                      key={node.id}
+                      type="button"
+                      className={styles.paletteItem}
+                      onClick={() => { focusNode(node.id); setShowPalette(false); setPaletteQuery(""); }}
+                    >
+                      <span
+                        className={styles.paletteItemDot}
+                        data-type={node.type}
+                      />
+                      <span className={styles.paletteItemLabel}>{node.label}</span>
+                      <span className={styles.paletteItemMeta}>{node.type}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              {paletteQuery !== "" && paletteNodes.length === 0 ? (
+                <div className={styles.paletteEmpty}>
+                  {locale === "pt" ? "Nenhum resultado encontrado." : "No results found."}
+                </div>
+              ) : null}
+            </div>
+
+            <div className={styles.paletteFooter}>
+              <span>setas: navegar</span>
+              <span>Enter selecionar</span>
+              <span>Esc fechar</span>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
-
-

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 
 import { hashPasswordSha256 } from "@/lib/passwordHash";
 import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
+import { brainOnUserCreated } from "@/lib/brain/autoSync";
 import { addAuditLogSafe } from "@/data/auditLogRepository";
 import { getAccessContext } from "@/lib/auth/session";
 import { getAdminUserItem, listAdminUserItems } from "@/lib/adminUsers";
@@ -232,6 +233,14 @@ export async function POST(req: NextRequest) {
   });
 
   console.error(`[ADMIN-USERS][POST] created admin=${admin?.email ?? "-"} user=${user?.email ?? user?.id}`);
+
+  brainOnUserCreated({
+    id: user.id,
+    name: user.user ?? user.email,
+    email: user.email ?? undefined,
+    role: user.role ?? undefined,
+  }).catch(() => {});
+
   const item = user ? await getAdminUserItem(user.id) : null;
   return NextResponse.json({ ok: true, item }, { status: 201 });
 }

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { listApplications, createApplication } from "../../../lib/applicationsStore";
 import { getCompanyIntegratedDefects } from "../../../lib/companyDefects";
+import { syncApplicationToBrain } from "@/lib/brain-sync";
 
 function normalizeProjectCode(value: unknown) {
   if (typeof value !== "string") return null;
@@ -83,6 +84,16 @@ export async function POST(request: Request) {
       companyId: body.companyId ?? body.companySlug ?? undefined,
       active: body.active ?? true,
     });
+    syncApplicationToBrain({
+      id: created.id,
+      name: created.name,
+      slug: created.slug,
+      description: created.description,
+      companyId: created.companyId ?? body.companyId ?? null,
+      active: created.active,
+      qaseProjectCode: created.qaseProjectCode,
+      source: created.source,
+    }).catch(() => {});
     return NextResponse.json({ item: created }, { status: 201 });
   } catch {
     return NextResponse.json({ error: "invalid body" }, { status: 400 });

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: Request) {
     if (!body.name) {
       return NextResponse.json({ error: "name is required" }, { status: 400 });
     }
-    const created = createApplication({
+    const created = await createApplication({
       name: String(body.name),
       slug: body.slug ? String(body.slug) : undefined,
       description: body.description ?? null,

--- a/app/api/brain/ask/route.ts
+++ b/app/api/brain/ask/route.ts
@@ -1,0 +1,113 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { gateway } from "@ai-sdk/gateway";
+import { streamText } from "ai";
+
+import { getGraphMetrics, getNodeWithContext, getRelatedMemories } from "@/lib/brain";
+import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
+
+export async function POST(req: NextRequest) {
+  const { admin, status } = await requireGlobalAdminWithStatus(req);
+  if (!admin) {
+    return NextResponse.json(
+      { error: status === 401 ? "Nao autorizado" : "Sem permissao" },
+      { status },
+    );
+  }
+
+  try {
+    const body = await req.json();
+    const { messages, nodeId } = body as {
+      messages: Array<{ role: "user" | "assistant"; content: string }>;
+      nodeId?: string | null;
+    };
+
+    if (!messages?.length) {
+      return NextResponse.json({ error: "Mensagens obrigatorias" }, { status: 400 });
+    }
+
+    const metrics = await getGraphMetrics();
+
+    let nodeContext = "";
+    if (nodeId) {
+      try {
+        const ctx = await getNodeWithContext(nodeId);
+        if (ctx?.node) {
+          const memories = await getRelatedMemories(nodeId, 2);
+          const neighborLabels = ctx.neighbors
+            .slice(0, 8)
+            .map((n: { label: string }) => n.label)
+            .join(", ");
+
+          nodeContext = [
+            `\n## No em foco: "${ctx.node.label}" (tipo: ${ctx.node.type})`,
+            ctx.node.description ? `Descricao: ${ctx.node.description}` : "",
+            `Conexoes de entrada: ${ctx.incoming.length} | Saida: ${ctx.outgoing.length}`,
+            neighborLabels ? `Vizinhos diretos: ${neighborLabels}` : "",
+            memories.length > 0
+              ? `\nMemorias associadas (${memories.length}):\n${memories
+                  .slice(0, 6)
+                  .map(
+                    (m: { memoryType: string; title: string; summary: string; importance: number }) =>
+                      `- [${m.memoryType} I${m.importance}] ${m.title}: ${m.summary}`,
+                  )
+                  .join("\n")}`
+              : "Sem memorias associadas.",
+          ]
+            .filter(Boolean)
+            .join("\n");
+        }
+      } catch {
+        // node context is optional
+      }
+    }
+
+    const systemPrompt = `Você é o **assistente neural da Testing Company** — empresa especialista em QA e qualidade de software.
+
+## Identidade
+- Empresa: Testing Company (plataforma de gestão de qualidade)
+- Função: Auxiliar equipes de QA a entender o grafo de conhecimento, identificar riscos, padrões e oportunidades de melhoria
+- Especialidade: Quality Assurance, testes de software, gestão de defeitos, releases, automações
+
+## Estado atual do Brain
+- Nós: ${metrics.nodeCount} | Conexões: ${metrics.edgeCount} | Memórias: ${metrics.memoryCount}
+- Grau médio: ${metrics.averageDegree} | Densidade: ${metrics.density.toFixed(4)}
+- Nós órfãos: ${metrics.orphanedNodes} | Ciclos detectados: ${metrics.cyclesDetected}
+${nodeContext}
+
+## Tipos de nós no sistema
+- **Company**: clientes/empresas gerenciadas pela Testing Company
+- **Application**: sistemas/apps de cada empresa
+- **Ticket**: chamados de suporte abertos pelos clientes
+- **Defect**: defeitos encontrados em testes (manuais ou via Qase/Jira)
+- **Release**: releases de teste (integradas Qase/Jira ou manuais)
+- **User**: membros da equipe e usuários das empresas
+- **Integration**: integrações ativas (Qase, Jira, etc.)
+- **Note**: notas capturadas durante o trabalho
+- **TestRun**: execuções de teste registradas
+
+## Como responder
+- Use português do Brasil, seja direto e acionável
+- Referencie nós, memórias e padrões do Brain quando relevante
+- Identifique riscos, conexões não óbvias e inconsistências
+- Para perguntas sobre QA, sugira estratégias baseadas no grafo
+- Quando falar de empresas/clientes, use os dados do Brain (nós tipo Company)
+- Formate com markdown quando ajudar na leitura
+- Se não tiver dados suficientes no Brain, sugira executar um sync completo`;
+
+    const result = streamText({
+      model: gateway("anthropic/claude-haiku-4-5-20251001"),
+      system: systemPrompt,
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+      maxTokens: 1024,
+    });
+
+    return result.toDataStream();
+  } catch (error) {
+    console.error("[brain/ask] POST error:", error);
+    return NextResponse.json({ error: "Erro ao processar pergunta" }, { status: 500 });
+  }
+}

--- a/app/api/brain/edges/route.ts
+++ b/app/api/brain/edges/route.ts
@@ -7,7 +7,10 @@ import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
 export async function GET(req: Request) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json(
+      { error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" },
+      { status },
+    );
   }
 
   const url = new URL(req.url);
@@ -31,7 +34,10 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json(
+      { error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" },
+      { status },
+    );
   }
 
   try {
@@ -39,13 +45,16 @@ export async function POST(req: Request) {
     const { fromId, toId, type, metadata } = body;
 
     if (!fromId || !toId || !type) {
-      return NextResponse.json({ error: "fromId, toId e type sao obrigatorios" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Origem, destino e tipo da conex\u00e3o s\u00e3o obrigat\u00f3rios" },
+        { status: 400 },
+      );
     }
 
     const edge = await connectNodes(fromId, toId, type, metadata, admin.id);
     return NextResponse.json({ edge }, { status: 201 });
   } catch (error) {
     console.error("[brain/edges] POST error:", error);
-    return NextResponse.json({ error: "Erro ao criar aresta" }, { status: 500 });
+    return NextResponse.json({ error: "Erro ao criar conex\u00e3o" }, { status: 500 });
   }
 }

--- a/app/api/brain/graph/route.ts
+++ b/app/api/brain/graph/route.ts
@@ -4,10 +4,65 @@ import { getSubgraph, searchNodes } from "@/lib/brain";
 import { prisma } from "@/lib/prismaClient";
 import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
 
+async function getMostConnectedNodeId() {
+  const [nodeSummaries, incomingByNode, outgoingByNode] = await Promise.all([
+    prisma.brainNode.findMany({
+      select: {
+        id: true,
+      },
+    }),
+    prisma.brainEdge.groupBy({
+      by: ["toId"],
+      _count: { id: true },
+    }),
+    prisma.brainEdge.groupBy({
+      by: ["fromId"],
+      _count: { id: true },
+    }),
+  ]);
+
+  const degreeMap = new Map<string, { inDegree: number; outDegree: number }>();
+
+  for (const group of incomingByNode) {
+    degreeMap.set(group.toId, {
+      inDegree: group._count.id,
+      outDegree: degreeMap.get(group.toId)?.outDegree ?? 0,
+    });
+  }
+
+  for (const group of outgoingByNode) {
+    degreeMap.set(group.fromId, {
+      inDegree: degreeMap.get(group.fromId)?.inDegree ?? 0,
+      outDegree: group._count.id,
+    });
+  }
+
+  const topConnectedNode = nodeSummaries
+    .map((node) => {
+      const degrees = degreeMap.get(node.id) ?? { inDegree: 0, outDegree: 0 };
+      const totalDegree = degrees.inDegree + degrees.outDegree;
+
+      return {
+        id: node.id,
+        inDegree: degrees.inDegree,
+        totalDegree,
+      };
+    })
+    .filter((node) => node.totalDegree > 0)
+    .sort(
+      (left, right) =>
+        right.totalDegree - left.totalDegree ||
+        right.inDegree - left.inDegree ||
+        left.id.localeCompare(right.id),
+    )[0];
+
+  return topConnectedNode?.id ?? null;
+}
+
 export async function GET(req: Request) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json({ error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" }, { status });
   }
 
   const url = new URL(req.url);
@@ -22,6 +77,9 @@ export async function GET(req: Request) {
       if (nodeType) {
         const nodes = await searchNodes({ type: nodeType, limit: 1 });
         rootId = nodes[0]?.id ?? null;
+      }
+      if (!rootId) {
+        rootId = await getMostConnectedNodeId();
       }
       if (!rootId) {
         const firstNode = await prisma.brainNode.findFirst({ orderBy: { createdAt: "asc" } });

--- a/app/api/brain/nodes/[id]/route.ts
+++ b/app/api/brain/nodes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import {
+  deleteNode,
   findSimilarNodes,
   getNodeAncestors,
   getNodeDescendants,
@@ -21,7 +22,10 @@ export async function GET(
 ) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json(
+      { error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" },
+      { status },
+    );
   }
 
   const { id } = await params;
@@ -87,6 +91,29 @@ export async function GET(
     return NextResponse.json(result);
   } catch (error) {
     console.error("[brain/nodes/id] GET error:", error);
-    return NextResponse.json({ error: "Erro ao buscar no" }, { status: 500 });
+    return NextResponse.json({ error: "Erro ao buscar n\u00f3" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { admin, status } = await requireGlobalAdminWithStatus(req);
+  if (!admin) {
+    return NextResponse.json(
+      { error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" },
+      { status },
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const result = await deleteNode(id, admin.id);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[brain/nodes/id] DELETE error:", error);
+    return NextResponse.json({ error: "Erro ao excluir n\u00f3" }, { status: 500 });
   }
 }

--- a/app/api/brain/nodes/[id]/timeline/route.ts
+++ b/app/api/brain/nodes/[id]/timeline/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getNodeTimeline } from "@/lib/brain";
+import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { admin, status } = await requireGlobalAdminWithStatus(req);
+  if (!admin) {
+    return NextResponse.json(
+      { error: status === 401 ? "Nao autorizado" : "Sem permissao" },
+      { status },
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const timeline = await getNodeTimeline(id);
+
+    return NextResponse.json({
+      timeline: timeline.map((entry) => ({
+        id: entry.id,
+        action: entry.action,
+        reason: entry.reason ?? null,
+        timestamp: entry.timestamp,
+      })),
+    });
+  } catch (error) {
+    console.error("[brain/nodes/[id]/timeline] GET error:", error);
+    return NextResponse.json({ error: "Erro ao buscar timeline" }, { status: 500 });
+  }
+}

--- a/app/api/brain/nodes/route.ts
+++ b/app/api/brain/nodes/route.ts
@@ -6,7 +6,10 @@ import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
 export async function GET(req: Request) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json(
+      { error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" },
+      { status },
+    );
   }
 
   const url = new URL(req.url);
@@ -22,7 +25,10 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json(
+      { error: status === 401 ? "N\u00e3o autorizado" : "Sem permiss\u00e3o" },
+      { status },
+    );
   }
 
   try {
@@ -30,7 +36,10 @@ export async function POST(req: Request) {
     const { type, label, refType, refId, description, metadata } = body;
 
     if (!type || !label) {
-      return NextResponse.json({ error: "type e label sao obrigatorios" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Tipo e nome do n\u00f3 s\u00e3o obrigat\u00f3rios" },
+        { status: 400 },
+      );
     }
 
     const node = await upsertNode({
@@ -46,6 +55,6 @@ export async function POST(req: Request) {
     return NextResponse.json({ node }, { status: 201 });
   } catch (error) {
     console.error("[brain/nodes] POST error:", error);
-    return NextResponse.json({ error: "Erro ao criar no" }, { status: 500 });
+    return NextResponse.json({ error: "Erro ao criar n\u00f3" }, { status: 500 });
   }
 }

--- a/app/api/brain/stats/route.ts
+++ b/app/api/brain/stats/route.ts
@@ -7,7 +7,7 @@ import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
 export async function GET(req: Request) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) {
-    return NextResponse.json({ error: status === 401 ? "Não autorizado" : "Sem permissão" }, { status });
+    return NextResponse.json({ error: status === 401 ? "Nao autorizado" : "Sem permissao" }, { status });
   }
 
   try {
@@ -129,13 +129,13 @@ export async function GET(req: Request) {
       alerts.push(...integrity.errors);
     }
     if (graphMetrics.orphanedNodes > 0) {
-      alerts.push(`${graphMetrics.orphanedNodes} nÃ³s sem conexÃ£o direta no grafo.`);
+      alerts.push(`${graphMetrics.orphanedNodes} nos sem conexao direta no grafo.`);
     }
     if (graphMetrics.cyclesDetected > 0) {
-      alerts.push(`${graphMetrics.cyclesDetected} ciclos detectados. Revisar relaÃ§Ãµes redundantes.`);
+      alerts.push(`${graphMetrics.cyclesDetected} ciclos detectados. Revisar relacoes redundantes.`);
     }
     if (graphMetrics.density < 0.015 && graphMetrics.nodeCount > 8) {
-      alerts.push("Grafo disperso: a densidade estÃ¡ baixa para o volume atual de nÃ³s.");
+      alerts.push("Grafo disperso: a densidade esta baixa para o volume atual de nos.");
     }
 
     return NextResponse.json({

--- a/app/api/brain/sync/route.ts
+++ b/app/api/brain/sync/route.ts
@@ -1,0 +1,27 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
+import { syncBrain } from "@/lib/brain-sync";
+
+export async function POST(req: NextRequest) {
+  const { admin, status } = await requireGlobalAdminWithStatus(req);
+  if (!admin) {
+    return NextResponse.json(
+      { error: status === 401 ? "Nao autorizado" : "Sem permissao" },
+      { status },
+    );
+  }
+
+  try {
+    const result = await syncBrain();
+    return NextResponse.json({
+      ok: true,
+      nodeCount: result.nodeCount,
+      edgeCount: result.edgeCount,
+      duration: result.duration,
+    });
+  } catch (error) {
+    console.error("[brain/sync] POST error:", error);
+    return NextResponse.json({ error: "Erro ao sincronizar Brain" }, { status: 500 });
+  }
+}

--- a/app/api/chamados/route.ts
+++ b/app/api/chamados/route.ts
@@ -9,6 +9,7 @@ import { assertCompanyAccess } from "@/lib/rbac/validateCompanyAccess";
 import { canAccessGlobalTicketWorkspace } from "@/lib/rbac/tickets";
 import { addAuditLogSafe } from "@/data/auditLogRepository";
 import { canCreateSupportTickets, canViewSupportBoard } from "@/lib/supportAccess";
+import { syncTicketToBrain } from "@/lib/brain-sync";
 
 function resolveDisplayName(user: { full_name?: string | null; name?: string | null; email?: string | null } | null | undefined) {
   return user?.full_name?.trim() || user?.name?.trim() || user?.email?.trim() || null;
@@ -101,6 +102,18 @@ export async function POST(req: Request) {
       entityLabel: suporte.title ?? null,
       metadata: { type: suporte.type ?? null, priority: suporte.priority ?? null, companyId: targetCompanyId, role: user.role ?? null, _payload: body },
     });
+
+    syncTicketToBrain({
+      id: suporte.id,
+      title: suporte.title,
+      description: suporte.description,
+      status: suporte.status,
+      priority: suporte.priority,
+      type: suporte.type,
+      companyId: suporte.companyId,
+      createdBy: suporte.createdBy,
+      assignedToUserId: suporte.assignedToUserId,
+    }).catch(() => {});
 
     return NextResponse.json({ item: enriched }, { status: 201 });
   } catch (err) {

--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { addAuditLogSafe } from "@/data/auditLogRepository";
 import { createLocalCompany, deleteLocalCompany, listLocalCompanies } from "@/lib/auth/localStore";
 import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
+import { syncCompanyToBrain } from "@/lib/brain-sync";
 
 export async function GET() {
   const companies = await listLocalCompanies();
@@ -52,6 +53,13 @@ export async function POST(req: Request) {
     integrations: integrations.length ? integrations : undefined,
     created_at: new Date().toISOString(),
   });
+  syncCompanyToBrain({
+    id: company.id,
+    name: company.name,
+    slug: company.slug,
+    status: (company as any).status ?? "active",
+    integration_mode: (company as any).integration_mode ?? "manual",
+  }).catch(() => {});
   return NextResponse.json(company, { status: 201 });
 }
 

--- a/app/api/kanban-columns/route.ts
+++ b/app/api/kanban-columns/route.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import { authenticateRequest } from "@/lib/jwtAuth";
 import { isDevRole } from "@/lib/rbac/devAccess";
-import { getJsonStoreDir } from "@/data/jsonStorePath";
+import { getJsonStorePath } from "@/data/jsonStorePath";
 import { canUsePersistentJsonStore, readPersistentJson, writePersistentJson } from "@/lib/persistentJsonStore";
 
 export const revalidate = 0;
@@ -21,7 +21,7 @@ const DEFAULT_COLUMNS: KanbanColumn[] = [
   { key: "done", label: "Concluido", locked: true },
 ];
 
-const STORE_PATH = path.join(getJsonStoreDir(), "kanban-columns.json");
+const STORE_PATH = getJsonStorePath("kanban-columns.json");
 const STORE_KEY = "qc:kanban_columns:v1";
 const USE_PERSISTENT_STORE = canUsePersistentJsonStore();
 

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { authenticateRequest } from "@/lib/jwtAuth";
 import { createUserNote, listUserNotes } from "@/lib/userNotesStore";
+import { syncNoteToBrain } from "@/lib/brain-sync";
 
 export async function GET(req: Request) {
   const user = await authenticateRequest(req);
@@ -31,6 +32,16 @@ export async function POST(req: Request) {
   if (!note) {
     return NextResponse.json({ error: "Informe título ou conteudo" }, { status: 400 });
   }
+
+  syncNoteToBrain({
+    id: note.id,
+    title: note.title,
+    content: note.content,
+    userId: user.id,
+    status: note.status,
+    priority: note.priority,
+    tags: note.tags,
+  }).catch(() => {});
 
   return NextResponse.json({ item: note }, { status: 201 });
 }

--- a/app/api/release-manual/route.ts
+++ b/app/api/release-manual/route.ts
@@ -6,6 +6,7 @@ import { authenticateRequest, type AuthUser } from "@/lib/jwtAuth";
 import { hasCapability, type Capability } from "@/lib/permissions";
 import { getJsonStoreDir } from "@/data/jsonStorePath";
 import { canUsePersistentJsonStore, readPersistentJson, writePersistentJson } from "@/lib/persistentJsonStore";
+import { syncReleaseManualToBrain } from "@/lib/brain-sync";
 
 type ManualRelease = {
   id: string;
@@ -119,6 +120,14 @@ export async function POST(req: NextRequest) {
   const releases = await readStore();
   releases.unshift(release);
   await writeStore(releases);
+
+  syncReleaseManualToBrain({
+    id: release.id,
+    title: release.title,
+    description: release.description,
+    status: release.status,
+    companyId: release.companyId,
+  }).catch(() => {});
 
   return NextResponse.json(release, { status: 201 });
 }

--- a/app/api/releases-manual/route.ts
+++ b/app/api/releases-manual/route.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import { slugifyRelease } from "@/lib/slugifyRelease";
 import { authenticateRequest, type AuthUser } from "@/lib/jwtAuth";
 import { canCreateManualDefect, getMockRole, resolveDefectRole } from "@/lib/rbac/defects";
+import { syncReleaseManualToBrain } from "@/lib/brain-sync";
 import type { Release, Stats } from "@/types/release";
 import { normalizeDefectStatus, resolveClosedAt } from "@/lib/defectNormalization";
 import { resolveManualReleaseKind } from "@/lib/manualReleaseKind";
@@ -218,6 +219,14 @@ export async function POST(req: Request) {
         passRate: total > 0 ? Math.round((release.stats.pass / total) * 100) : 0,
       },
     };
+
+    syncReleaseManualToBrain({
+      id: release.id,
+      title: release.name,
+      description: release.observations ?? null,
+      status: release.status ?? null,
+      companyId: release.clientSlug ?? null,
+    }).catch(() => {});
 
     return NextResponse.json(payload, { status: 201 });
   } catch (error) {

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -5,6 +5,7 @@ import { authenticateRequest } from "@/lib/jwtAuth";
 import { canCreateRun, canDeleteRun, getRunMockRole, resolveRunRole } from "@/lib/rbac/runs";
 import { addAuditLogSafe } from "@/data/auditLogRepository";
 import { notifyIntegrationRunCreated } from "@/lib/notificationService";
+import { syncReleaseToBrain } from "@/lib/brain-sync";
 
 // Garantir ambiente Node para fs
 export const runtime = "nodejs";
@@ -133,6 +134,15 @@ export async function POST(request: Request) {
       manualSummary: release.manualSummary ?? null,
       metrics: null,
     };
+
+    syncReleaseToBrain({
+      id: release.slug,
+      title: release.title,
+      slug: release.slug,
+      summary: release.summary ?? null,
+      status: release.status ?? "ACTIVE",
+      companyId: release.clientId ?? null,
+    }).catch(() => {});
 
     return NextResponse.json({ release: payload });
   } catch (error) {

--- a/app/hooks/useBrain.ts
+++ b/app/hooks/useBrain.ts
@@ -185,3 +185,18 @@ export function useBrainMemories(nodeId: string | null) {
     revalidateOnFocus: false,
   });
 }
+
+export type BrainTimelineEntry = {
+  id: string;
+  action: string;
+  reason: string | null;
+  timestamp: string;
+};
+
+export function useBrainTimeline(nodeId: string | null) {
+  const key = nodeId ? `/api/brain/nodes/${nodeId}/timeline` : null;
+
+  return useSWR<{ timeline: BrainTimelineEntry[] }>(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+}

--- a/data/jsonStorePath.ts
+++ b/data/jsonStorePath.ts
@@ -1,18 +1,36 @@
 import path from "node:path";
 
+function getJsonStoreOverride() {
+  return process.env.JSON_STORE_DIR?.trim();
+}
+
+function getWorkerStoreName() {
+  const worker = process.env.PLAYWRIGHT_WORKER_INDEX?.trim();
+  return worker ? `e2e-worker-${worker}` : null;
+}
+
 export function getJsonStoreDir() {
-  const override = process.env.JSON_STORE_DIR?.trim();
+  const override = getJsonStoreOverride();
   if (override) return override;
   // When running Playwright in parallel, use a per-worker subdir to avoid
   // cross-test interference when the app falls back to file-backed JSON.
-  const base = path.join(process.cwd(), "data");
-  const worker = process.env.PLAYWRIGHT_WORKER_INDEX;
-  if (worker && worker.trim() !== "") {
-    return path.join(base, `e2e-worker-${worker}`);
+  const workerStoreName = getWorkerStoreName();
+  if (workerStoreName) {
+    return path.join(/*turbopackIgnore: true*/ process.cwd(), "data", workerStoreName);
   }
-  return base;
+  return path.join(/*turbopackIgnore: true*/ process.cwd(), "data");
 }
 
 export function getJsonStorePath(filename: string) {
-  return path.join(getJsonStoreDir(), filename);
+  const override = getJsonStoreOverride();
+  if (override) {
+    return path.join(/*turbopackIgnore: true*/ override, filename);
+  }
+
+  const workerStoreName = getWorkerStoreName();
+  if (workerStoreName) {
+    return path.join(/*turbopackIgnore: true*/ process.cwd(), "data", workerStoreName, filename);
+  }
+
+  return path.join(/*turbopackIgnore: true*/ process.cwd(), "data", filename);
 }

--- a/docs/brain-admin-refresh.md
+++ b/docs/brain-admin-refresh.md
@@ -1,0 +1,41 @@
+# Brain Admin Refresh
+
+## Objetivo
+
+Dar ao Brain uma leitura mais proxima de um mapa neural real: fundo contido, arestas discretas, poucos pontos de destaque e uma lateral que ajuda a interpretar o grafo sem poluir a tela.
+
+## O que foi aplicado
+
+- `app/admin/brain/BrainGraphView.tsx`
+  - Reestruturado para uma navegacao orientada por contexto.
+  - Busca agora serve para localizar e focar nos, sem filtrar o grafo inteiro apos a selecao.
+  - A simulacao do canvas foi estabilizada com colecoes memoizadas para evitar reinicios desnecessarios.
+  - O painel lateral usa `stats`, `graphMetrics`, `topConnectedNodes`, `alerts`, `suggestions`, `similarNodes`, `relatedMemories`, `ancestors`, `descendants` e `impact`.
+- `app/admin/brain/Brain.module.css`
+  - Novo layout com topbar em camadas, HUD flutuante, legenda compacta e painel lateral com blocos modulares.
+  - Visual dark-first inspirado na referencia anexada, mas com fallback consistente para tema claro.
+  - `-webkit-backdrop-filter` aplicado nos elementos com blur para manter compatibilidade com Safari.
+- `app/api/brain/stats/route.ts`
+  - Strings de alerta normalizadas para o painel nao exibir texto quebrado.
+
+## Linguagem visual
+
+- Hub forte: ponto claro com maior peso visual.
+- Foco atual: verde, com halo sutil.
+- Periferia: cinza reduzido para nao disputar atencao.
+- Arestas: discretas por padrao, reforcadas quando tocam foco, raiz ou impacto.
+- Painel: primeiro mostra panorama do Brain; ao selecionar um no, troca para leitura operacional desse contexto.
+
+## Contratos de dados usados na tela
+
+- `useBrainGraph(rootNodeId, depth)`
+- `useBrainStats()`
+- `useBrainNodeContext(selectedNodeId, depth)`
+- `useBrainSearch(query, type, 8)`
+
+## Regras para manter
+
+- Nao voltar a usar a busca como filtro estrutural do grafo; ela deve ser navegacao.
+- Se surgirem novos `node.type` ou `memoryType`, atualizar os mapas de cor em `BrainGraphView.tsx`.
+- Se o painel crescer, manter o principio atual: panorama sem selecao, detalhe profundo com selecao.
+- Qualquer bloco novo no painel deve entrar como secao modular, sem reintroduzir cards redundantes no topo.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".next-e2e/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/lib/automationPool.ts
+++ b/lib/automationPool.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import pg from "pg";
+import { resolveDatabaseUrlFromEnv } from "@/lib/databaseUrl";
 
 const { Pool } = pg;
 
@@ -7,14 +8,11 @@ type PoolGlobal = { automationPool?: pg.Pool };
 const g = globalThis as unknown as PoolGlobal;
 
 function createPool(): pg.Pool {
-  const url =
-    process.env.AUTOMATION_POSTGRES_URL ||
-    process.env.AUTOMATION_PRISMA_DATABASE_URL ||
-    process.env.AUTOMATION_DATABASE_URL;
+  const url = resolveDatabaseUrlFromEnv("automation");
 
   if (!url) {
     throw new Error(
-      "AUTOMATION_POSTGRES_URL, AUTOMATION_PRISMA_DATABASE_URL or AUTOMATION_DATABASE_URL is required.",
+      "AUTOMATION_DATABASE_URL, AUTOMATION_PRISMA_DATABASE_URL, PRISMA_DATABASE_URL, AUTOMATION_POSTGRES_PRISMA_URL, AUTOMATION_POSTGRES_URL, POSTGRES_PRISMA_URL, POSTGRES_URL or DATABASE_URL is required.",
     );
   }
 

--- a/lib/automationPool.ts
+++ b/lib/automationPool.ts
@@ -14,7 +14,7 @@ function createPool(): pg.Pool {
 
   if (!url) {
     throw new Error(
-      "AUTOMATION_POSTGRES_URL or AUTOMATION_PRISMA_DATABASE_URL is required.",
+      "AUTOMATION_POSTGRES_URL, AUTOMATION_PRISMA_DATABASE_URL or AUTOMATION_DATABASE_URL is required.",
     );
   }
 
@@ -27,17 +27,26 @@ function createPool(): pg.Pool {
   });
 }
 
-export const automationPool: pg.Pool = g.automationPool ?? createPool();
-
-if (process.env.NODE_ENV !== "production") {
-  g.automationPool = automationPool;
+export function getAutomationPool(): pg.Pool {
+  if (!g.automationPool) {
+    g.automationPool = createPool();
+  }
+  return g.automationPool;
 }
+
+export const automationPool: pg.Pool = new Proxy({} as pg.Pool, {
+  get(_target, property) {
+    const pool = getAutomationPool();
+    const value = pool[property as keyof pg.Pool];
+    return typeof value === "function" ? value.bind(pool) : value;
+  },
+});
 
 /**
  * Ensures all automation tables exist. Safe to call on every request (uses IF NOT EXISTS).
  */
 export async function ensureAutomationTables(): Promise<void> {
-  await automationPool.query(`
+  await getAutomationPool().query(`
     CREATE TABLE IF NOT EXISTS automation_scripts (
       id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
       company_slug TEXT NOT NULL,

--- a/lib/automations/biometrics/attachRunner.ts
+++ b/lib/automations/biometrics/attachRunner.ts
@@ -79,7 +79,7 @@ export type BiometricAttachExecution = {
 };
 
 function toRelativeOutputPath(filePath: string) {
-  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+  return path.relative(/*turbopackIgnore: true*/ process.cwd(), filePath).replace(/\\/g, "/");
 }
 
 function resolveConfig(config?: Partial<BiometricApiConfig>): BiometricApiConfig {
@@ -111,7 +111,7 @@ function resolveFingerprintInput(input: BiometricAttachInput) {
     throw new Error("Informe uma fixture biométrica ou um arquivo de digital.");
   }
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/*turbopackIgnore: true*/ filePath)) {
     throw new Error(`Arquivo de digital não encontrado: ${filePath}`);
   }
 
@@ -134,7 +134,7 @@ function resolveFaceInput(input: BiometricAttachInput) {
   const filePath = input.faceFilePath || fixture?.path || "";
 
   if (!filePath) return null;
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/*turbopackIgnore: true*/ filePath)) {
     throw new Error(`Arquivo de face não encontrado: ${filePath}`);
   }
 
@@ -150,7 +150,7 @@ function resolveFaceInput(input: BiometricAttachInput) {
 }
 
 async function buildFingerprintPayload(input: BiometricAttachInput, filePath: string) {
-  const inputBuffer = fs.readFileSync(filePath);
+  const inputBuffer = fs.readFileSync(/*turbopackIgnore: true*/ filePath);
   const mode: BiometricAttachMode = String(input.mode || "below").trim().toUpperCase() === "ABOVE" ? "ABOVE" : "BELOW";
   const target = Number(input.target || (mode === "ABOVE" ? "520000" : String(MAX_FINGERPRINT_BASE64_LENGTH)));
 
@@ -267,8 +267,10 @@ async function attachBiometrics(config: BiometricApiConfig, token: string, proce
 }
 
 function ensureGeneratedDir(outputDir?: string | null) {
-  const dir = path.resolve(process.cwd(), outputDir || path.join("generated", "biometrics"));
-  fs.mkdirSync(dir, { recursive: true });
+  const dir = outputDir?.trim()
+    ? path.resolve(/*turbopackIgnore: true*/ process.cwd(), outputDir)
+    : path.join(/*turbopackIgnore: true*/ process.cwd(), "generated", "biometrics");
+  fs.mkdirSync(/*turbopackIgnore: true*/ dir, { recursive: true });
   return dir;
 }
 
@@ -305,7 +307,7 @@ export async function runBiometricAttach(input: BiometricAttachInput): Promise<B
   const token = await obtainToken(config);
   const processId = await resolveProcessId(config, token, input);
   const preparedFingerprint = await buildFingerprintPayload(input, fingerprint.filePath);
-  const faceBase64 = face ? fs.readFileSync(face.filePath).toString("base64") : null;
+  const faceBase64 = face ? fs.readFileSync(/*turbopackIgnore: true*/ face.filePath).toString("base64") : null;
 
   const body = {
     data: [
@@ -369,8 +371,8 @@ export async function runBiometricAttach(input: BiometricAttachInput): Promise<B
     user: config.user,
   };
 
-  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
-  fs.writeFileSync(latestOutputPath, JSON.stringify(result, null, 2));
+  fs.writeFileSync(/*turbopackIgnore: true*/ outputPath, JSON.stringify(result, null, 2));
+  fs.writeFileSync(/*turbopackIgnore: true*/ latestOutputPath, JSON.stringify(result, null, 2));
 
   return result;
 }

--- a/lib/automations/biometrics/localFixtures.ts
+++ b/lib/automations/biometrics/localFixtures.ts
@@ -13,9 +13,16 @@ export type LocalBiometricFixture = {
 };
 
 export const DEFAULT_BIOMETRIC_FIXTURES_DIR =
-  process.env.BIOMETRIC_FIXTURES_DIR || "C:\\Users\\Testing Company\\Pictures\\Screenshots\\Digitais";
+  process.env.BIOMETRIC_FIXTURES_DIR?.trim() ||
+  path.join(/*turbopackIgnore: true*/ process.cwd(), "data", "biometric-fixtures");
 
-const fixturePath = (fileName: string) => path.join(DEFAULT_BIOMETRIC_FIXTURES_DIR, fileName);
+const fixturePath = (fileName: string) => {
+  const override = process.env.BIOMETRIC_FIXTURES_DIR?.trim();
+  if (override) {
+    return path.join(/*turbopackIgnore: true*/ override, fileName);
+  }
+  return path.join(/*turbopackIgnore: true*/ process.cwd(), "data", "biometric-fixtures", fileName);
+};
 
 export const LOCAL_BIOMETRIC_FIXTURES: LocalBiometricFixture[] = BIOMETRIC_FIXTURE_DEFINITIONS.map((fixture) => ({
   ...fixture,
@@ -23,7 +30,7 @@ export const LOCAL_BIOMETRIC_FIXTURES: LocalBiometricFixture[] = BIOMETRIC_FIXTU
 }));
 
 export function resolveExistingLocalBiometricFixtures() {
-  return LOCAL_BIOMETRIC_FIXTURES.filter((fixture) => fs.existsSync(fixture.path));
+  return LOCAL_BIOMETRIC_FIXTURES.filter((fixture) => fs.existsSync(/*turbopackIgnore: true*/ fixture.path));
 }
 
 export function findLocalBiometricFixture(slug: string) {

--- a/lib/brain-sync.ts
+++ b/lib/brain-sync.ts
@@ -1,0 +1,653 @@
+/**
+ * brain-sync.ts
+ * Fire-and-forget helper functions that keep the Brain in sync when system
+ * entities are created or updated. Each function is safe to call without await
+ * — they never throw, just log errors.
+ *
+ * Pattern in API routes:
+ *   syncTicketToBrain(ticket).catch(() => {});
+ */
+
+import { prisma } from "@/lib/prismaClient";
+import { upsertNode, connectNodes } from "@/lib/brain";
+
+/* ─── helpers ─────────────────────────────────────────────────────────────── */
+
+async function findBrainNode(refType: string, refId: string) {
+  return prisma.brainNode.findFirst({ where: { refType, refId } });
+}
+
+async function safeConnect(
+  fromRefType: string,
+  fromRefId: string,
+  toRefType: string,
+  toRefId: string,
+  edgeType: string,
+  meta?: Record<string, unknown>,
+) {
+  const [from, to] = await Promise.all([
+    findBrainNode(fromRefType, fromRefId),
+    findBrainNode(toRefType, toRefId),
+  ]);
+  if (from && to) {
+    await connectNodes(from.id, to.id, edgeType, meta);
+  }
+}
+
+/* ─── Company ─────────────────────────────────────────────────────────────── */
+
+export async function syncCompanyToBrain(company: {
+  id: string;
+  name: string;
+  slug: string;
+  status?: string | null;
+  short_description?: string | null;
+  integration_mode?: string | null;
+  website?: string | null;
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Company",
+      label: company.name,
+      refType: "Company",
+      refId: company.id,
+      description: company.short_description ?? undefined,
+      metadata: {
+        slug: company.slug,
+        status: company.status ?? "active",
+        website: company.website ?? null,
+        integrationMode: company.integration_mode ?? "manual",
+      },
+    });
+  } catch (err) {
+    console.error("[brain-sync] syncCompanyToBrain error:", err);
+  }
+}
+
+/* ─── CompanyIntegration ──────────────────────────────────────────────────── */
+
+export async function syncIntegrationToBrain(integration: {
+  id: string;
+  companyId: string;
+  type: string;
+}): Promise<void> {
+  try {
+    const node = await upsertNode({
+      type: "Integration",
+      label: `${integration.type} Integration`,
+      refType: "CompanyIntegration",
+      refId: integration.id,
+      description: `Integração ${integration.type}`,
+      metadata: { integrationType: integration.type, companyId: integration.companyId },
+    });
+    await safeConnect("Integration", integration.id, "Company", integration.companyId, "BELONGS_TO");
+    return void node;
+  } catch (err) {
+    console.error("[brain-sync] syncIntegrationToBrain error:", err);
+  }
+}
+
+/* ─── Application ─────────────────────────────────────────────────────────── */
+
+export async function syncApplicationToBrain(app: {
+  id: string;
+  name: string;
+  slug?: string | null;
+  description?: string | null;
+  companyId?: string | null;
+  active?: boolean | null;
+  qaseProjectCode?: string | null;
+  source?: string | null;
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Application",
+      label: app.name,
+      refType: "Application",
+      refId: app.id,
+      description: app.description ?? undefined,
+      metadata: {
+        slug: app.slug,
+        companyId: app.companyId,
+        active: app.active ?? true,
+        qaseProjectCode: app.qaseProjectCode ?? null,
+        source: app.source ?? "manual",
+      },
+    });
+    if (app.companyId) {
+      await safeConnect("Application", app.id, "Company", app.companyId, "BELONGS_TO");
+    }
+  } catch (err) {
+    console.error("[brain-sync] syncApplicationToBrain error:", err);
+  }
+}
+
+/* ─── User ────────────────────────────────────────────────────────────────── */
+
+export async function syncUserToBrain(user: {
+  id: string;
+  name: string;
+  email?: string | null;
+  role?: string | null;
+  job_title?: string | null;
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "User",
+      label: user.name,
+      refType: "User",
+      refId: user.id,
+      metadata: {
+        email: user.email ?? null,
+        role: user.role ?? "user",
+        jobTitle: user.job_title ?? null,
+      },
+    });
+  } catch (err) {
+    console.error("[brain-sync] syncUserToBrain error:", err);
+  }
+}
+
+/* ─── Ticket ──────────────────────────────────────────────────────────────── */
+
+export async function syncTicketToBrain(ticket: {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  status?: string | null;
+  priority?: string | null;
+  type?: string | null;
+  companyId?: string | null;
+  createdBy?: string | null;
+  assignedToUserId?: string | null;
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Ticket",
+      label: ticket.title ?? `Ticket ${ticket.id.slice(0, 8)}`,
+      refType: "Ticket",
+      refId: ticket.id,
+      description: ticket.description ?? undefined,
+      metadata: {
+        status: ticket.status ?? "backlog",
+        priority: ticket.priority ?? "medium",
+        ticketType: ticket.type ?? "tarefa",
+        companyId: ticket.companyId ?? null,
+      },
+    });
+    if (ticket.companyId) {
+      await safeConnect("Ticket", ticket.id, "Company", ticket.companyId, "BELONGS_TO");
+    }
+    if (ticket.createdBy) {
+      await safeConnect("Ticket", ticket.id, "User", ticket.createdBy, "CREATED_BY");
+    }
+    if (ticket.assignedToUserId) {
+      await safeConnect("Ticket", ticket.id, "User", ticket.assignedToUserId, "ASSIGNED_TO");
+    }
+  } catch (err) {
+    console.error("[brain-sync] syncTicketToBrain error:", err);
+  }
+}
+
+/* ─── Defect ──────────────────────────────────────────────────────────────── */
+
+export async function syncDefectToBrain(defect: {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  companyId?: string | null;
+  status?: string | null;
+  assignedToUserId?: string | null;
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Defect",
+      label: defect.title ?? `Defect ${defect.id.slice(0, 8)}`,
+      refType: "Defect",
+      refId: defect.id,
+      description: defect.description ?? undefined,
+      metadata: {
+        status: defect.status ?? "open",
+        companyId: defect.companyId ?? null,
+      },
+    });
+    if (defect.companyId) {
+      await safeConnect("Defect", defect.id, "Company", defect.companyId, "BELONGS_TO");
+    }
+    if (defect.assignedToUserId) {
+      await safeConnect("Defect", defect.id, "User", defect.assignedToUserId, "ASSIGNED_TO");
+    }
+  } catch (err) {
+    console.error("[brain-sync] syncDefectToBrain error:", err);
+  }
+}
+
+/* ─── Release ─────────────────────────────────────────────────────────────── */
+
+export async function syncReleaseToBrain(release: {
+  id: string;
+  title?: string | null;
+  slug?: string | null;
+  summary?: string | null;
+  status?: string | null;
+  companyId?: string | null;
+  createdByUserId?: string | null;
+  assignedToUserId?: string | null;
+  statsPass?: number | null;
+  statsFail?: number | null;
+  statsBlocked?: number | null;
+  environments?: string[];
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Release",
+      label: release.title ?? release.slug ?? `Release ${release.id.slice(0, 8)}`,
+      refType: "Release",
+      refId: release.id,
+      description: release.summary ?? undefined,
+      metadata: {
+        slug: release.slug,
+        status: release.status ?? "DRAFT",
+        companyId: release.companyId ?? null,
+        statsPass: release.statsPass ?? 0,
+        statsFail: release.statsFail ?? 0,
+        statsBlocked: release.statsBlocked ?? 0,
+        environments: release.environments ?? [],
+      },
+    });
+    if (release.companyId) {
+      await safeConnect("Release", release.id, "Company", release.companyId, "BELONGS_TO");
+    }
+    if (release.createdByUserId) {
+      await safeConnect("Release", release.id, "User", release.createdByUserId, "CREATED_BY");
+    }
+    if (release.assignedToUserId) {
+      await safeConnect("Release", release.id, "User", release.assignedToUserId, "ASSIGNED_TO");
+    }
+  } catch (err) {
+    console.error("[brain-sync] syncReleaseToBrain error:", err);
+  }
+}
+
+/* ─── ReleaseManual ───────────────────────────────────────────────────────── */
+
+export async function syncReleaseManualToBrain(release: {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  status?: string | null;
+  companyId?: string | null;
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Release",
+      label: release.title ?? `Release Manual ${release.id.slice(0, 8)}`,
+      refType: "ReleaseManual",
+      refId: release.id,
+      description: release.description ?? undefined,
+      metadata: {
+        status: release.status ?? "draft",
+        companyId: release.companyId ?? null,
+        source: "manual",
+      },
+    });
+    if (release.companyId) {
+      await safeConnect("Release", release.id, "Company", release.companyId, "BELONGS_TO");
+    }
+  } catch (err) {
+    console.error("[brain-sync] syncReleaseManualToBrain error:", err);
+  }
+}
+
+/* ─── UserNote ────────────────────────────────────────────────────────────── */
+
+export async function syncNoteToBrain(note: {
+  id: string;
+  title?: string | null;
+  content?: string | null;
+  userId?: string | null;
+  status?: string | null;
+  priority?: string | null;
+  tags?: string[];
+}): Promise<void> {
+  try {
+    await upsertNode({
+      type: "Note",
+      label: note.title ?? `Nota ${note.id.slice(0, 8)}`,
+      refType: "UserNote",
+      refId: note.id,
+      description: note.content?.slice(0, 200) ?? undefined,
+      metadata: {
+        status: note.status ?? "Rascunho",
+        priority: note.priority ?? "Baixa",
+        tags: note.tags ?? [],
+        userId: note.userId ?? null,
+      },
+    });
+    if (note.userId) {
+      await safeConnect("Note", note.id, "User", note.userId, "CREATED_BY");
+    }
+  } catch (err) {
+    console.error("[brain-sync] syncNoteToBrain error:", err);
+  }
+}
+
+/* ─── Full Sync ───────────────────────────────────────────────────────────── */
+
+export async function syncBrain() {
+  const log = (msg: string) => console.log(`[SYNC] ${msg}`)
+  const logError = (msg: string, error?: any) =>
+    console.error(`[SYNC ERROR] ${msg}`, error?.message || '')
+
+  log('===== STARTING BRAIN SYNC — Testing Company Platform =====')
+  const startTime = Date.now()
+
+  try {
+    log('Step 0: Ensuring Testing Company root node...')
+    await upsertNode({
+      type: 'Company',
+      label: 'Testing Company',
+      refType: 'Platform',
+      refId: 'testing-company-root',
+      description: 'Plataforma de QA da Testing Company — nó raiz do Brain',
+      isRoot: true,
+      metadata: {
+        slug: 'testing-company',
+        status: 'active',
+        website: 'https://testingcompany.com.br',
+        integrationMode: 'platform',
+        identity: 'root',
+      },
+    })
+    log('✓ Testing Company root node ready')
+
+    // ===== STEP 1: Nodes
+    log('Step 1: Creating nodes from entities...')
+    let nodeCount = 0
+
+    // ── Companies
+    const companies = await prisma.company.findMany()
+    for (const company of companies) {
+      await upsertNode({
+        type: 'Company',
+        label: company.name,
+        refType: 'Company',
+        refId: company.id,
+        description: company.short_description ?? undefined,
+        metadata: {
+          slug: company.slug,
+          status: company.status,
+          website: company.website ?? null,
+          integrationMode: company.integration_mode ?? 'manual',
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${companies.length} Company nodes`)
+
+    // ── Applications
+    const applications = await prisma.application.findMany()
+    for (const app of applications) {
+      await upsertNode({
+        type: 'Application',
+        label: app.name,
+        refType: 'Application',
+        refId: app.id,
+        description: app.description ?? undefined,
+        metadata: {
+          slug: app.slug,
+          companyId: app.companyId,
+          active: app.active,
+          qaseProjectCode: app.qaseProjectCode ?? null,
+          source: app.source ?? 'manual',
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${applications.length} Application nodes`)
+
+    // ── Users
+    const users = await prisma.user.findMany()
+    for (const user of users) {
+      await upsertNode({
+        type: 'User',
+        label: user.name,
+        refType: 'User',
+        refId: user.id,
+        metadata: {
+          email: user.email,
+          role: user.role,
+          jobTitle: user.job_title ?? null,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${users.length} User nodes`)
+
+    // ── Tickets
+    const tickets = await prisma.ticket.findMany()
+    for (const ticket of tickets) {
+      await upsertNode({
+        type: 'Ticket',
+        label: ticket.title,
+        refType: 'Ticket',
+        refId: ticket.id,
+        description: ticket.description ?? undefined,
+        metadata: {
+          status: ticket.status,
+          priority: ticket.priority,
+          ticketType: ticket.type,
+          companyId: ticket.companyId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${tickets.length} Ticket nodes`)
+
+    // ── Defects
+    const defects = await prisma.defect.findMany()
+    for (const defect of defects) {
+      await upsertNode({
+        type: 'Defect',
+        label: defect.title,
+        refType: 'Defect',
+        refId: defect.id,
+        description: defect.description ?? undefined,
+        metadata: {
+          companyId: defect.companyId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${defects.length} Defect nodes`)
+
+    // ── Releases (Qase / Jira synced)
+    const releases = await prisma.release.findMany()
+    for (const release of releases) {
+      await upsertNode({
+        type: 'Release',
+        label: release.title,
+        refType: 'Release',
+        refId: release.id,
+        description: release.summary ?? undefined,
+        metadata: {
+          slug: release.slug,
+          status: release.status,
+          companyId: release.companyId ?? null,
+          statsPass: release.statsPass,
+          statsFail: release.statsFail,
+          statsBlocked: release.statsBlocked,
+          environments: release.environments,
+          source: release.source,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${releases.length} Release nodes`)
+
+    // ── CompanyIntegrations
+    const integrations = await prisma.companyIntegration.findMany()
+    for (const integration of integrations) {
+      await upsertNode({
+        type: 'Integration',
+        label: `${integration.type} Integration`,
+        refType: 'CompanyIntegration',
+        refId: integration.id,
+        description: `Integração ${integration.type}`,
+        metadata: {
+          integrationType: integration.type,
+          companyId: integration.companyId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${integrations.length} Integration nodes`)
+
+    // ── UserNotes
+    const notes = await prisma.userNote.findMany({ take: 500 })
+    for (const note of notes) {
+      await upsertNode({
+        type: 'Note',
+        label: note.title,
+        refType: 'UserNote',
+        refId: note.id,
+        description: note.content.slice(0, 200),
+        metadata: {
+          status: note.status,
+          priority: note.priority,
+          tags: note.tags,
+          userId: note.userId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${notes.length} Note nodes`)
+
+    // ── TestRuns
+    const testRuns = await prisma.testRun.findMany({ take: 200 })
+    for (const run of testRuns) {
+      await upsertNode({
+        type: 'TestRun',
+        label: `TestRun ${run.id.slice(0, 8)}`,
+        refType: 'TestRun',
+        refId: run.id,
+        metadata: { status: run.status },
+      })
+      nodeCount++
+    }
+    log(`Created ${testRuns.length} TestRun nodes`)
+
+    log(`✓ Total nodes created/updated: ${nodeCount}`)
+
+    // ===== STEP 2: Edges
+    log('Step 2: Creating edges between entities...')
+    let edgeCount = 0
+
+    async function findNode(refType: string, refId: string) {
+      return prisma.brainNode.findFirst({ where: { refType, refId } })
+    }
+
+    async function safeConnectNodes(
+      fromRefType: string, fromRefId: string,
+      toRefType: string, toRefId: string,
+      edgeType: string,
+      meta?: Record<string, unknown>,
+    ) {
+      const [from, to] = await Promise.all([
+        findNode(fromRefType, fromRefId),
+        findNode(toRefType, toRefId),
+      ])
+      if (from && to) {
+        await connectNodes(from.id, to.id, edgeType, meta).catch(() => {})
+        edgeCount++
+      }
+    }
+
+    // Testing Company root → all Companies (RELATES_TO)
+    const rootNode = await findNode('Platform', 'testing-company-root')
+    if (rootNode) {
+      for (const company of companies) {
+        const cn = await findNode('Company', company.id)
+        if (cn) {
+          await connectNodes(rootNode.id, cn.id, 'RELATES_TO').catch(() => {})
+          edgeCount++
+        }
+      }
+    }
+
+    // Company → Application (BELONGS_TO)
+    for (const app of applications) {
+      if (app.companyId) {
+        await safeConnectNodes('Application', app.id, 'Company', app.companyId, 'BELONGS_TO')
+      }
+    }
+
+    // Company → Integration (BELONGS_TO)
+    for (const integration of integrations) {
+      await safeConnectNodes('Integration', integration.id, 'Company', integration.companyId, 'BELONGS_TO')
+    }
+
+    // Ticket → Company (BELONGS_TO)
+    for (const ticket of tickets) {
+      if (ticket.companyId) {
+        await safeConnectNodes('Ticket', ticket.id, 'Company', ticket.companyId, 'BELONGS_TO')
+      }
+      // Ticket → User (CREATED_BY)
+      if (ticket.createdBy) {
+        await safeConnectNodes('Ticket', ticket.id, 'User', ticket.createdBy, 'CREATED_BY')
+      }
+      // Ticket → User (ASSIGNED_TO)
+      if (ticket.assignedToUserId) {
+        await safeConnectNodes('Ticket', ticket.id, 'User', ticket.assignedToUserId, 'ASSIGNED_TO')
+      }
+    }
+
+    // Defect → Company (BELONGS_TO)
+    for (const defect of defects) {
+      if (defect.companyId) {
+        await safeConnectNodes('Defect', defect.id, 'Company', defect.companyId, 'BELONGS_TO')
+      }
+    }
+
+    // Release → Company (BELONGS_TO), Release → User (CREATED_BY / ASSIGNED_TO)
+    for (const release of releases) {
+      if (release.companyId) {
+        await safeConnectNodes('Release', release.id, 'Company', release.companyId, 'BELONGS_TO')
+      }
+      if (release.createdByUserId) {
+        await safeConnectNodes('Release', release.id, 'User', release.createdByUserId, 'CREATED_BY')
+      }
+      if (release.assignedToUserId) {
+        await safeConnectNodes('Release', release.id, 'User', release.assignedToUserId, 'ASSIGNED_TO')
+      }
+    }
+
+    // User → Company (MEMBER_OF) via Membership
+    const memberships = await prisma.membership.findMany()
+    for (const membership of memberships) {
+      await safeConnectNodes('User', membership.userId, 'Company', membership.companyId, 'MEMBER_OF', {
+        role: membership.role,
+      })
+    }
+
+    // Note → User (CREATED_BY)
+    for (const note of notes) {
+      await safeConnectNodes('Note', note.id, 'User', note.userId, 'CREATED_BY')
+    }
+
+    log(`✓ Total edges created: ${edgeCount}`)
+
+    const duration = Date.now() - startTime
+    log(`===== SYNC COMPLETED in ${duration}ms =====`)
+
+    return {
+      success: true,
+      nodeCount,
+      edgeCount,
+      duration,
+    }
+  } catch (error) {
+    logError('SYNC FAILED', error)
+    throw error
+  }
+}

--- a/lib/brain-sync.ts
+++ b/lib/brain-sync.ts
@@ -10,6 +10,7 @@
 
 import { prisma } from "@/lib/prismaClient";
 import { upsertNode, connectNodes } from "@/lib/brain";
+import type { Prisma } from "@prisma/client";
 
 /* ─── helpers ─────────────────────────────────────────────────────────────── */
 
@@ -23,7 +24,7 @@ async function safeConnect(
   toRefType: string,
   toRefId: string,
   edgeType: string,
-  meta?: Record<string, unknown>,
+  meta?: Prisma.InputJsonValue,
 ) {
   const [from, to] = await Promise.all([
     findBrainNode(fromRefType, fromRefId),
@@ -350,7 +351,6 @@ export async function syncBrain() {
       refType: 'Platform',
       refId: 'testing-company-root',
       description: 'Plataforma de QA da Testing Company — nó raiz do Brain',
-      isRoot: true,
       metadata: {
         slug: 'testing-company',
         status: 'active',
@@ -551,7 +551,7 @@ export async function syncBrain() {
       fromRefType: string, fromRefId: string,
       toRefType: string, toRefId: string,
       edgeType: string,
-      meta?: Record<string, unknown>,
+      meta?: Prisma.InputJsonValue,
     ) {
       const [from, to] = await Promise.all([
         findNode(fromRefType, fromRefId),

--- a/lib/databaseUrl.ts
+++ b/lib/databaseUrl.ts
@@ -20,7 +20,9 @@ export function resolveDatabaseUrlFromEnv(scope: DatabaseScope = "default") {
           process.env.PRISMA_DATABASE_URL,
           process.env.AUTOMATION_POSTGRES_PRISMA_URL,
           process.env.AUTOMATION_POSTGRES_URL,
+          process.env.POSTGRES_PRISMA_URL,
           process.env.POSTGRES_URL,
+          process.env.DATABASE_URL,
         )
       : firstDefined(
           process.env.DATABASE_URL,

--- a/lib/prismaClientOptions.ts
+++ b/lib/prismaClientOptions.ts
@@ -42,7 +42,7 @@ function getDatabaseUrl(scope: DatabaseScope = "default") {
   if (!databaseUrl) {
     throw new Error(
       scope === "automation"
-        ? "AUTOMATION_DATABASE_URL, AUTOMATION_PRISMA_DATABASE_URL, PRISMA_DATABASE_URL, AUTOMATION_POSTGRES_PRISMA_URL, AUTOMATION_POSTGRES_URL or POSTGRES_URL is required to initialize Prisma for automation scope."
+        ? "AUTOMATION_DATABASE_URL, AUTOMATION_PRISMA_DATABASE_URL, PRISMA_DATABASE_URL, AUTOMATION_POSTGRES_PRISMA_URL, AUTOMATION_POSTGRES_URL, POSTGRES_PRISMA_URL, POSTGRES_URL or DATABASE_URL is required to initialize Prisma for automation scope."
         : "DATABASE_URL, PRISMA_DATABASE_URL, POSTGRES_PRISMA_URL or POSTGRES_URL is required to initialize Prisma.",
     );
   }

--- a/lib/qualityGateHistory.ts
+++ b/lib/qualityGateHistory.ts
@@ -1,17 +1,13 @@
 import "server-only";
 
-import { canUsePersistentJsonStore, readPersistentJson, writePersistentJson } from "@/lib/persistentJsonStore";
+import fs from "node:fs/promises";
+import path from "node:path";
 
-let fs: typeof import("fs/promises") | undefined;
-let path: typeof import("path") | undefined;
-if (typeof process !== "undefined" && process.release?.name === "node") {
-  fs = require("fs/promises");
-  path = require("path");
-}
+import { canUsePersistentJsonStore, readPersistentJson, writePersistentJson } from "@/lib/persistentJsonStore";
 
 const USE_MEMORY_ALERTS =
   process.env.QUALITY_ALERTS_IN_MEMORY === "true" || process.env.NODE_ENV === "test";
-const STORE_PATH = path && path.join(/*turbopackIgnore: true*/ process.cwd(), "data", "quality_gate_history.json");
+const STORE_PATH = path.join(/*turbopackIgnore: true*/ process.cwd(), "data", "quality_gate_history.json");
 const STORE_KEY = "qc:quality_gate_history:v1";
 const USE_PERSISTENT_STORE = !USE_MEMORY_ALERTS && canUsePersistentJsonStore();
 
@@ -37,7 +33,6 @@ export type QualityGateHistoryEntry = {
 
 async function ensureStore() {
   if (USE_MEMORY_ALERTS || USE_PERSISTENT_STORE) return;
-  if (!fs || !path || !STORE_PATH) return;
   await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
   try {
     await fs.access(STORE_PATH);
@@ -59,7 +54,6 @@ export async function appendQualityGateHistory(entry: QualityGateHistoryEntry) {
     return;
   }
 
-  if (!fs || !STORE_PATH) return;
   try {
     await ensureStore();
     const raw = await fs.readFile(STORE_PATH, "utf8");
@@ -89,7 +83,6 @@ export async function readQualityGateHistory(
     const persisted = await readPersistentJson<QualityGateHistoryEntry[]>(STORE_KEY, []);
     arr = Array.isArray(persisted) ? persisted : [];
   } else {
-    if (!fs || !STORE_PATH) return [];
     try {
       await ensureStore();
       const raw = await fs.readFile(STORE_PATH, "utf8");

--- a/scripts/sync-brain.ts
+++ b/scripts/sync-brain.ts
@@ -1,3 +1,5 @@
+import { readdir } from 'node:fs/promises'
+import path from 'node:path'
 import { prisma } from '@/lib/prismaClient'
 import {
   upsertNode,
@@ -10,26 +12,246 @@ const logError = (msg: string, error?: any) =>
   console.error(`[SYNC ERROR] ${msg}`, error?.message || '')
 
 /**
- * Sincronização inicial do Brain
- * Popula BrainNode, BrainEdge e valida integridade
+ * Retorna o nó do Brain para uma entidade (por refType + refId)
+ */
+async function findNode(refType: string, refId: string) {
+  return prisma.brainNode.findFirst({ where: { refType, refId } })
+}
+
+/**
+ * Cria aresta entre dois nós por refType/refId (idempotente)
+ */
+async function safeConnect(
+  fromRefType: string, fromRefId: string,
+  toRefType: string, toRefId: string,
+  edgeType: string,
+  meta?: Record<string, unknown>,
+) {
+  const [from, to] = await Promise.all([
+    findNode(fromRefType, fromRefId),
+    findNode(toRefType, toRefId),
+  ])
+  if (from && to) {
+    await connectNodes(from.id, to.id, edgeType, meta).catch(() => {/* already exists */})
+  }
+}
+
+type SystemRouteKind = 'page' | 'api'
+
+type SystemRouteEntry = {
+  refId: string
+  kind: SystemRouteKind
+  routePath: string
+  filePath: string
+  label: string
+  description: string
+  moduleRefId: string
+  moduleLabel: string
+  moduleDescription: string
+  submoduleRefId: string | null
+  submoduleLabel: string | null
+  submoduleDescription: string | null
+}
+
+const APP_DIR = path.join(process.cwd(), 'app')
+
+const SYSTEM_MODULE_LABELS: Record<string, string> = {
+  home: 'Plataforma',
+  api: 'APIs',
+  admin: 'Administracao',
+  automacoes: 'Automacoes',
+  empresas: 'Empresas',
+  dashboard: 'Dashboard',
+  docs: 'Documentacao',
+  applications: 'Aplicacoes',
+  'applications-hub': 'Aplicacoes',
+  'applications-panel': 'Aplicacoes',
+  clients: 'Clientes',
+  profile: 'Perfil',
+  settings: 'Configuracoes',
+  login: 'Acesso',
+  requests: 'Solicitacoes',
+  metrics: 'Metricas',
+  runs: 'Runs',
+  release: 'Releases',
+  chamados: 'Chamados',
+  chat: 'Chat',
+  documentos: 'Documentos',
+  issues: 'Issues',
+}
+
+function toPosix(value: string) {
+  return value.split(path.sep).join('/')
+}
+
+function capitalizeWords(value: string) {
+  return value
+    .split(' ')
+    .filter(Boolean)
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+    .join(' ')
+}
+
+function normalizeSegment(segment: string) {
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    return `:${segment.slice(1, -1)}`
+  }
+
+  return segment.replace(/[-_]/g, ' ')
+}
+
+function routeLabelFromPath(routePath: string, kind: SystemRouteKind) {
+  if (routePath === '/') {
+    return kind === 'api' ? 'Endpoint raiz da API' : 'Tela inicial da plataforma'
+  }
+
+  const humanPath = routePath
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => capitalizeWords(normalizeSegment(segment)))
+    .join(' / ')
+
+  return kind === 'api' ? `Endpoint ${humanPath}` : `Tela ${humanPath}`
+}
+
+function routeDescriptionFromFile(routePath: string, filePath: string, kind: SystemRouteKind) {
+  if (kind === 'api') {
+    return `Endpoint do sistema mapeado automaticamente a partir de ${filePath}. Rota: ${routePath}.`
+  }
+
+  return `Tela da plataforma mapeada automaticamente a partir de ${filePath}. Rota: ${routePath}.`
+}
+
+function buildRoutePath(relativeFilePath: string) {
+  const parts = toPosix(relativeFilePath).split('/').filter(Boolean)
+  const routeParts = parts
+    .slice(0, -1)
+    .filter((segment) => !segment.startsWith('('))
+    .filter((segment) => !segment.startsWith('_'))
+
+  if (routeParts.length === 0) return '/'
+  return `/${routeParts.join('/')}`
+}
+
+function buildModuleLabel(segment: string) {
+  return SYSTEM_MODULE_LABELS[segment] ?? capitalizeWords(normalizeSegment(segment))
+}
+
+function buildSystemRouteEntry(relativeFilePath: string): SystemRouteEntry | null {
+  const normalized = toPosix(relativeFilePath)
+  const isPage = normalized === 'page.tsx' || normalized.endsWith('/page.tsx')
+  const isApiRoute = normalized.startsWith('api/') && normalized.endsWith('/route.ts')
+
+  if (!isPage && !isApiRoute) return null
+
+  const kind: SystemRouteKind = isApiRoute ? 'api' : 'page'
+  const routePath = buildRoutePath(normalized)
+  const routeSegments = routePath.split('/').filter(Boolean)
+  const moduleSegment = kind === 'api' ? 'api' : routeSegments[0] ?? 'home'
+  const submoduleSegment =
+    kind === 'api'
+      ? routeSegments[1] ?? null
+      : routeSegments.length >= 2
+        ? routeSegments[1]
+        : null
+
+  const moduleRefId = `${kind}:module:${moduleSegment}`
+  const moduleLabel = buildModuleLabel(moduleSegment)
+  const moduleDescription =
+    kind === 'api'
+      ? `Agrupa os endpoints da area ${moduleLabel.toLowerCase()} do sistema.`
+      : `Agrupa telas e fluxos da area ${moduleLabel.toLowerCase()} da plataforma.`
+
+  const submoduleRefId =
+    submoduleSegment != null
+      ? `${kind}:submodule:${moduleSegment}/${submoduleSegment}`
+      : null
+  const submoduleLabel =
+    submoduleSegment != null
+      ? `${moduleLabel} / ${buildModuleLabel(submoduleSegment)}`
+      : null
+  const submoduleDescription =
+    submoduleLabel != null
+      ? `Recorte funcional ${submoduleLabel.toLowerCase()} dentro do Brain.`
+      : null
+
+  return {
+    refId: `${kind}:${routePath}`,
+    kind,
+    routePath,
+    filePath: normalized,
+    label: routeLabelFromPath(routePath, kind),
+    description: routeDescriptionFromFile(routePath, normalized, kind),
+    moduleRefId,
+    moduleLabel,
+    moduleDescription,
+    submoduleRefId,
+    submoduleLabel,
+    submoduleDescription,
+  }
+}
+
+async function collectRouteFiles(dir: string, baseDir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue
+    if (entry.name === 'node_modules') continue
+
+    const absolutePath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await collectRouteFiles(absolutePath, baseDir)))
+      continue
+    }
+
+    if (entry.name !== 'page.tsx' && entry.name !== 'route.ts') continue
+    files.push(path.relative(baseDir, absolutePath))
+  }
+
+  return files
+}
+
+async function collectSystemRoutes(): Promise<SystemRouteEntry[]> {
+  const files = await collectRouteFiles(APP_DIR, APP_DIR)
+  return files
+    .map((filePath) => buildSystemRouteEntry(filePath))
+    .filter((entry): entry is SystemRouteEntry => entry != null)
+}
+
+/**
+ * Sincronização completa do Brain.
+ * Cobre: Companies, Applications, Tickets, Defects, Users,
+ *        Releases, ReleaseManuals, CompanyIntegrations, UserNotes, TestRuns
  */
 export async function syncBrain() {
-  log('===== STARTING BRAIN SYNC =====')
+  log('===== STARTING BRAIN SYNC — Testing Company Platform =====')
   const startTime = Date.now()
 
   try {
-    // ===== STEP 1: Limpar dados antigos (opcional)
-    // await prisma.brainAuditLog.deleteMany({})
-    // await prisma.brainMemory.deleteMany({})
-    // await prisma.brainEdge.deleteMany({})
-    // await prisma.brainNode.deleteMany({})
-    // log('Cleaned old brain data')
+    log('Step 0: Ensuring Testing Company root node...')
+    await upsertNode({
+      type: 'Company',
+      label: 'Testing Company',
+      refType: 'Platform',
+      refId: 'testing-company-root',
+      description: 'Plataforma de QA da Testing Company — nó raiz do Brain',
+      isRoot: true,
+      metadata: {
+        slug: 'testing-company',
+        status: 'active',
+        website: 'https://testingcompany.com.br',
+        integrationMode: 'platform',
+        identity: 'root',
+      },
+    })
+    log('✓ Testing Company root node ready')
 
-    // ===== STEP 2: Criar nós para cada entidade
+    // ===== STEP 1: Nodes
     log('Step 1: Creating nodes from entities...')
     let nodeCount = 0
 
-    // Companies
+    // ── Companies
     const companies = await prisma.company.findMany()
     for (const company of companies) {
       await upsertNode({
@@ -37,16 +259,19 @@ export async function syncBrain() {
         label: company.name,
         refType: 'Company',
         refId: company.id,
-        description: company.short_description || undefined,
+        description: company.short_description ?? undefined,
         metadata: {
+          slug: company.slug,
           status: company.status,
+          website: company.website ?? null,
+          integrationMode: company.integration_mode ?? 'manual',
         },
       })
       nodeCount++
     }
     log(`Created ${companies.length} Company nodes`)
 
-    // Applications
+    // ── Applications
     const applications = await prisma.application.findMany()
     for (const app of applications) {
       await upsertNode({
@@ -54,53 +279,20 @@ export async function syncBrain() {
         label: app.name,
         refType: 'Application',
         refId: app.id,
-        description: app.description || undefined,
+        description: app.description ?? undefined,
         metadata: {
+          slug: app.slug,
           companyId: app.companyId,
-          status: app.active ? 'active' : 'inactive',
+          active: app.active,
+          qaseProjectCode: app.qaseProjectCode ?? null,
+          source: app.source ?? 'manual',
         },
       })
       nodeCount++
     }
     log(`Created ${applications.length} Application nodes`)
 
-    // Tickets
-    const tickets = await prisma.ticket.findMany()
-    for (const ticket of tickets) {
-      await upsertNode({
-        type: 'Ticket',
-        label: ticket.title,
-        refType: 'Ticket',
-        refId: ticket.id,
-        description: ticket.description || undefined,
-        metadata: {
-          companyId: ticket.companyId,
-          status: ticket.status,
-          priority: ticket.priority,
-        },
-      })
-      nodeCount++
-    }
-    log(`Created ${tickets.length} Ticket nodes`)
-
-    // Defects
-    const defects = await prisma.defect.findMany()
-    for (const defect of defects) {
-      await upsertNode({
-        type: 'Defect',
-        label: defect.title,
-        refType: 'Defect',
-        refId: defect.id,
-        description: defect.description || undefined,
-        metadata: {
-          companyId: defect.companyId,
-        },
-      })
-      nodeCount++
-    }
-    log(`Created ${defects.length} Defect nodes`)
-
-    // Users
+    // ── Users
     const users = await prisma.user.findMany()
     for (const user of users) {
       await upsertNode({
@@ -111,117 +303,334 @@ export async function syncBrain() {
         metadata: {
           email: user.email,
           role: user.role,
+          jobTitle: user.job_title ?? null,
         },
       })
       nodeCount++
     }
     log(`Created ${users.length} User nodes`)
 
-    log(`✓ Total nodes created: ${nodeCount}`)
+    // ── Tickets
+    const tickets = await prisma.ticket.findMany()
+    for (const ticket of tickets) {
+      await upsertNode({
+        type: 'Ticket',
+        label: ticket.title,
+        refType: 'Ticket',
+        refId: ticket.id,
+        description: ticket.description ?? undefined,
+        metadata: {
+          status: ticket.status,
+          priority: ticket.priority,
+          ticketType: ticket.type,
+          companyId: ticket.companyId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${tickets.length} Ticket nodes`)
 
-    // ===== STEP 3: Criar arestas entre entidades
+    // ── Defects
+    const defects = await prisma.defect.findMany()
+    for (const defect of defects) {
+      await upsertNode({
+        type: 'Defect',
+        label: defect.title,
+        refType: 'Defect',
+        refId: defect.id,
+        description: defect.description ?? undefined,
+        metadata: {
+          companyId: defect.companyId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${defects.length} Defect nodes`)
+
+    // ── Releases (Qase / Jira synced)
+    const releases = await prisma.release.findMany()
+    for (const release of releases) {
+      await upsertNode({
+        type: 'Release',
+        label: release.title,
+        refType: 'Release',
+        refId: release.id,
+        description: release.summary ?? undefined,
+        metadata: {
+          slug: release.slug,
+          status: release.status,
+          companyId: release.companyId ?? null,
+          statsPass: release.statsPass,
+          statsFail: release.statsFail,
+          statsBlocked: release.statsBlocked,
+          environments: release.environments,
+          source: release.source,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${releases.length} Release nodes`)
+
+    // ── ReleaseManuals (releases manuais)
+    const releaseManuals = await prisma.releaseManual.findMany()
+    for (const rm of releaseManuals) {
+      await upsertNode({
+        type: 'Release',
+        label: rm.title,
+        refType: 'ReleaseManual',
+        refId: rm.id,
+        description: rm.description ?? undefined,
+        metadata: {
+          status: rm.status,
+          companyId: rm.companyId,
+          source: 'manual',
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${releaseManuals.length} ReleaseManual nodes`)
+
+    // ── CompanyIntegrations
+    const integrations = await prisma.companyIntegration.findMany()
+    for (const integration of integrations) {
+      await upsertNode({
+        type: 'Integration',
+        label: `${integration.type} Integration`,
+        refType: 'CompanyIntegration',
+        refId: integration.id,
+        description: `Integração ${integration.type}`,
+        metadata: {
+          integrationType: integration.type,
+          companyId: integration.companyId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${integrations.length} Integration nodes`)
+
+    // ── UserNotes
+    const notes = await prisma.userNote.findMany({ take: 500 })
+    for (const note of notes) {
+      await upsertNode({
+        type: 'Note',
+        label: note.title,
+        refType: 'UserNote',
+        refId: note.id,
+        description: note.content.slice(0, 200),
+        metadata: {
+          status: note.status,
+          priority: note.priority,
+          tags: note.tags,
+          userId: note.userId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${notes.length} Note nodes`)
+
+    // ── TestRuns
+    const testRuns = await prisma.testRun.findMany({ take: 200 })
+    for (const run of testRuns) {
+      await upsertNode({
+        type: 'TestRun',
+        label: `TestRun ${run.id.slice(0, 8)}`,
+        refType: 'TestRun',
+        refId: run.id,
+        metadata: { status: run.status },
+      })
+      nodeCount++
+    }
+    log(`Created ${testRuns.length} TestRun nodes`)
+
+    const systemRoutes = await collectSystemRoutes()
+    const modules = new Map<
+      string,
+      { label: string; description: string; kind: SystemRouteKind }
+    >()
+    const submodules = new Map<
+      string,
+      { label: string; description: string; parentRefId: string; kind: SystemRouteKind }
+    >()
+
+    for (const entry of systemRoutes) {
+      if (!modules.has(entry.moduleRefId)) {
+        modules.set(entry.moduleRefId, {
+          label: entry.moduleLabel,
+          description: entry.moduleDescription,
+          kind: entry.kind,
+        })
+      }
+
+      if (entry.submoduleRefId && entry.submoduleLabel && entry.submoduleDescription) {
+        submodules.set(entry.submoduleRefId, {
+          label: entry.submoduleLabel,
+          description: entry.submoduleDescription,
+          parentRefId: entry.moduleRefId,
+          kind: entry.kind,
+        })
+      }
+    }
+
+    for (const [refId, moduleEntry] of modules) {
+      await upsertNode({
+        type: 'Module',
+        label: moduleEntry.label,
+        refType: 'SystemModule',
+        refId,
+        description: moduleEntry.description,
+        metadata: {
+          source: 'app-router',
+          kind: moduleEntry.kind,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${modules.size} system Module nodes`)
+
+    for (const [refId, submoduleEntry] of submodules) {
+      await upsertNode({
+        type: 'Module',
+        label: submoduleEntry.label,
+        refType: 'SystemSubmodule',
+        refId,
+        description: submoduleEntry.description,
+        metadata: {
+          source: 'app-router',
+          kind: submoduleEntry.kind,
+          parentRefId: submoduleEntry.parentRefId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${submodules.size} system submodule nodes`)
+
+    for (const entry of systemRoutes) {
+      await upsertNode({
+        type: 'Screen',
+        label: entry.label,
+        refType: 'SystemScreen',
+        refId: entry.refId,
+        description: entry.description,
+        metadata: {
+          source: 'app-router',
+          routePath: entry.routePath,
+          routeKind: entry.kind,
+          filePath: entry.filePath,
+          moduleRefId: entry.moduleRefId,
+          submoduleRefId: entry.submoduleRefId,
+        },
+      })
+      nodeCount++
+    }
+    log(`Created ${systemRoutes.length} Screen nodes for pages and endpoints`)
+
+    log(`✓ Total nodes created/updated: ${nodeCount}`)
+
+    // ===== STEP 2: Edges
     log('Step 2: Creating edges between entities...')
     let edgeCount = 0
 
+    // Testing Company root → all Companies (RELATES_TO)
+    const rootNode = await findNode('Platform', 'testing-company-root')
+    if (rootNode) {
+      for (const company of companies) {
+        const cn = await findNode('Company', company.id)
+        if (cn) {
+          await connectNodes(rootNode.id, cn.id, 'RELATES_TO').catch(() => {})
+          edgeCount++
+        }
+      }
+    }
+
     // Company → Application (HAS_APPLICATION)
     for (const app of applications) {
-      const companyNode = await prisma.brainNode.findFirst({
-        where: { refType: 'Company', refId: app.companyId },
-      })
-      const appNode = await prisma.brainNode.findFirst({
-        where: { refType: 'Application', refId: app.id },
-      })
-      if (companyNode && appNode) {
-        await connectNodes(companyNode.id, appNode.id, 'HAS_APPLICATION')
+      if (app.companyId) {
+        await safeConnect('Application', app.id, 'Company', app.companyId, 'BELONGS_TO')
         edgeCount++
       }
     }
-    log(`Created Application edges`)
+
+    // Company → Integration (HAS_INTEGRATION)
+    for (const integration of integrations) {
+      await safeConnect('Integration', integration.id, 'Company', integration.companyId, 'BELONGS_TO')
+      edgeCount++
+    }
 
     // Ticket → Company (BELONGS_TO)
     for (const ticket of tickets) {
-      const ticketNode = await prisma.brainNode.findFirst({
-        where: { refType: 'Ticket', refId: ticket.id },
-      })
-      const companyNode = await prisma.brainNode.findFirst({
-        where: { refType: 'Company', refId: ticket.companyId },
-      })
-      if (ticketNode && companyNode) {
-        await connectNodes(ticketNode.id, companyNode.id, 'BELONGS_TO')
+      if (ticket.companyId) {
+        await safeConnect('Ticket', ticket.id, 'Company', ticket.companyId, 'BELONGS_TO')
+        edgeCount++
+      }
+      // Ticket → User (CREATED_BY)
+      if (ticket.createdBy) {
+        await safeConnect('Ticket', ticket.id, 'User', ticket.createdBy, 'CREATED_BY')
+        edgeCount++
+      }
+      // Ticket → User (ASSIGNED_TO)
+      if (ticket.assignedToUserId) {
+        await safeConnect('Ticket', ticket.id, 'User', ticket.assignedToUserId, 'ASSIGNED_TO')
         edgeCount++
       }
     }
-    log(`Created Ticket-Company edges`)
 
-    // Ticket → User (CREATED_BY)
-    for (const ticket of tickets) {
-      if (ticket.createdBy) {
-        const ticketNode = await prisma.brainNode.findFirst({
-          where: { refType: 'Ticket', refId: ticket.id },
-        })
-        const userNode = await prisma.brainNode.findFirst({
-          where: { refType: 'User', refId: ticket.createdBy },
-        })
-        if (ticketNode && userNode) {
-          await connectNodes(ticketNode.id, userNode.id, 'CREATED_BY')
-          edgeCount++
-        }
+    // Defect → Company (BELONGS_TO)
+    for (const defect of defects) {
+      if (defect.companyId) {
+        await safeConnect('Defect', defect.id, 'Company', defect.companyId, 'BELONGS_TO')
+        edgeCount++
       }
     }
-    log(`Created Ticket-Creator edges`)
 
-    // Ticket → User (ASSIGNED_TO)
-    for (const ticket of tickets) {
-      if (ticket.assignedToUserId) {
-        const ticketNode = await prisma.brainNode.findFirst({
-          where: { refType: 'Ticket', refId: ticket.id },
-        })
-        const userNode = await prisma.brainNode.findFirst({
-          where: { refType: 'User', refId: ticket.assignedToUserId },
-        })
-        if (ticketNode && userNode) {
-          await connectNodes(ticketNode.id, userNode.id, 'ASSIGNED_TO')
-          edgeCount++
-        }
+    // Release → Company (BELONGS_TO), Release → User (CREATED_BY / ASSIGNED_TO)
+    for (const release of releases) {
+      if (release.companyId) {
+        await safeConnect('Release', release.id, 'Company', release.companyId, 'BELONGS_TO')
+        edgeCount++
+      }
+      if (release.createdByUserId) {
+        await safeConnect('Release', release.id, 'User', release.createdByUserId, 'CREATED_BY')
+        edgeCount++
+      }
+      if (release.assignedToUserId) {
+        await safeConnect('Release', release.id, 'User', release.assignedToUserId, 'ASSIGNED_TO')
+        edgeCount++
       }
     }
-    log(`Created Ticket-Assignee edges`)
 
-    // User → Company (MEMBER_OF)
+    // ReleaseManual → Company (BELONGS_TO)
+    for (const rm of releaseManuals) {
+      await safeConnect('Release', rm.id, 'Company', rm.companyId, 'BELONGS_TO')
+      edgeCount++
+    }
+
+    // User → Company (MEMBER_OF) via Membership
     const memberships = await prisma.membership.findMany()
     for (const membership of memberships) {
-      const userNode = await prisma.brainNode.findFirst({
-        where: { refType: 'User', refId: membership.userId },
+      await safeConnect('User', membership.userId, 'Company', membership.companyId, 'MEMBER_OF', {
+        role: membership.role,
       })
-      const companyNode = await prisma.brainNode.findFirst({
-        where: { refType: 'Company', refId: membership.companyId },
-      })
-      if (userNode && companyNode) {
-        await connectNodes(userNode.id, companyNode.id, 'MEMBER_OF', {
-          role: membership.role,
-        })
-        edgeCount++
-      }
+      edgeCount++
     }
-    log(`Created User-Company edges`)
+
+    // Note → User (CREATED_BY)
+    for (const note of notes) {
+      await safeConnect('Note', note.id, 'User', note.userId, 'CREATED_BY')
+      edgeCount++
+    }
 
     log(`✓ Total edges created: ${edgeCount}`)
 
-    // ===== STEP 4: Validar integridade
+    // ===== STEP 3: Validate
     log('Step 3: Validating integrity...')
     const validation = await validateBrainIntegrity()
-
     if (validation.valid) {
       log(`✓ Brain integrity: VALID`)
     } else {
-      logError('Brain integrity: INVALID', {
-        errors: validation.errors,
-      })
+      logError('Brain integrity issues', { errors: validation.errors })
     }
+    log(`\nStats:\n  - Nodes: ${validation.stats.nodes}\n  - Edges: ${validation.stats.edges}\n  - Memories: ${validation.stats.memories}`)
 
-    log(`\nStats:\n  - Nodes: ${validation.stats.nodes}\n  - Edges: ${validation.stats.edges}\n  - Memories: ${validation.stats.memories}\n    `)
-
-    // ===== STEP 5: Registrar conclusão
     const duration = Date.now() - startTime
     log(`===== SYNC COMPLETED in ${duration}ms =====`)
 

--- a/scripts/sync-brain.ts
+++ b/scripts/sync-brain.ts
@@ -1,6 +1,7 @@
 import { readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { prisma } from '@/lib/prismaClient'
+import type { Prisma } from '@prisma/client'
 import {
   upsertNode,
   connectNodes,
@@ -25,7 +26,7 @@ async function safeConnect(
   fromRefType: string, fromRefId: string,
   toRefType: string, toRefId: string,
   edgeType: string,
-  meta?: Record<string, unknown>,
+  meta?: Prisma.InputJsonValue,
 ) {
   const [from, to] = await Promise.all([
     findNode(fromRefType, fromRefId),
@@ -236,7 +237,6 @@ export async function syncBrain() {
       refType: 'Platform',
       refId: 'testing-company-root',
       description: 'Plataforma de QA da Testing Company — nó raiz do Brain',
-      isRoot: true,
       metadata: {
         slug: 'testing-company',
         status: 'active',


### PR DESCRIPTION
## O que mudou
- Refresh completo do Brain Admin (layout, topbar/HUD, legenda e painel lateral por contexto).
- Busca passa a navegar/focar em nós (sem filtrar estruturalmente o grafo após selecionar).
- Ajustes/expansões nas rotas do Brain (`/api/brain/*`), incluindo `ask`, `sync` e timeline de nó.
- Script/infra de sync do Brain e documentação do refresh.

## Por que
Melhorar a leitura do grafo (mais “mapa neural”) e deixar a navegação por contexto mais rápida/estável.

## Validação
- `npm run lint` (falha por erros já existentes fora do escopo; adicionado ignore para `.next-e2e/**` em `eslint.config.mjs`).
