### PR TITLE
fix(kanban): suportar status PT em runs manuais

### DIFF
--- a/app/components/Kanban.tsx
+++ b/app/components/Kanban.tsx
@@ -138,6 +138,12 @@ export default function Kanban({
     if (lower === "notrun" || lower === "not_run" || lower === "not run" || lower === "untested" || lower === "notrun") return "notRun";
 
     const upper = raw.toUpperCase();
+    // Portuguese statuses used by manual runs
+    if (upper === "APROVADO") return "pass";
+    if (upper === "FALHA") return "fail";
+    if (upper === "BLOQUEADO") return "blocked";
+    if (upper === "NAO_EXECUTADO") return "notRun";
+
     if (upper === "PASS" || upper === "PASSED") return "pass";
     if (upper === "FAIL" || upper === "FAILED") return "fail";
     if (upper === "BLOCKED") return "blocked";
@@ -1155,7 +1161,6 @@ export default function Kanban({
     </div>
   );
 }
-
 
 
 


### PR DESCRIPTION
﻿O Kanban carregava cards persistidos de runs manuais com status em PT (APROVADO/FALHA/BLOQUEADO/NAO_EXECUTADO), mas o normalizador so aceitava PASS/FAIL/BLOCKED/NOT_RUN.

Isso fazia o detalhe mostrar resumo com totais, mas quadro/lista vazio ("Cases nao disponiveis").

Esta mudanca mapeia os status PT para as colunas corretas.
