### PR TITLE
[codex] fix: reuse run detail kanban

### DIFF
--- a/app/integrations/qase.ts
+++ b/app/integrations/qase.ts
@@ -428,6 +428,11 @@ export async function getQaseRunCases(project: string, runId: number, slug?: str
     }
   }
 
+  if (allCases.length === 0) {
+    console.warn(`${logBase} empty /cases response for runId=${runId} - trying /result`);
+    return fetchAllQaseResults(ctx, runId);
+  }
+
   return allCases;
 }
 

--- a/app/release/components/RunKanbanSection.tsx
+++ b/app/release/components/RunKanbanSection.tsx
@@ -1,37 +1,26 @@
-import { RunDetailKanbanSection } from "@/components/RunDetailKanbanSection";
-import { RunKanbanStream } from "../RunKanbanStream";
+import { RunDetailKanbanPanel } from "@/empresas/[slug]/runs/RunDetailKanbanPanel";
 import type { RunDetailViewModel } from "@/lib/runDetailViewModel";
-import type { ReleaseEntry } from "../data";
 
 export function RunKanbanSection({ vm }: { vm: RunDetailViewModel }) {
   const companySlug = vm.companySlug !== "demo" ? vm.companySlug : undefined;
 
   return (
     <section>
-      {vm.source === "API" ? (
-        <RunKanbanStream
-          projectKey={vm.projectKey}
-          projectCode={vm.projectCode}
-          runId={(vm.releaseData as ReleaseEntry).runId ?? 0}
-          companySlug={companySlug}
-          persistEndpoint={vm.apiPersistEndpoint}
-          editable={false}
-          allowStatusChange={false}
-          allowLinkEdit={vm.canPersistApiLinks}
-        />
-      ) : (
-        <RunDetailKanbanSection
-          data={{ pass: [], fail: [], blocked: [], notRun: [] }}
-          project={vm.projectKey}
-          runId={0}
-          qaseProject={vm.projectCode}
-          companySlug={companySlug}
-          persistEndpoint={`/api/releases-manual/${vm.releaseData.slug}/cases`}
-          editable={true}
-          allowStatusChange={true}
-          allowLinkEdit={false}
-        />
-      )}
+      <RunDetailKanbanPanel
+        run={{
+          slug: vm.releaseData.slug,
+          sourceType: vm.source === "MANUAL" ? "manual" : "integrated",
+          applicationLabel: vm.appMeta.label,
+          projectCode: vm.projectCode,
+          runId: vm.runId,
+          stats: {
+            ...vm.stats,
+            total: vm.total,
+          },
+          raw: vm.releaseData as Record<string, unknown>,
+        }}
+        companySlug={companySlug}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## O que mudou

- A tela completa de detalhe da run agora reutiliza `RunDetailKanbanPanel`, o mesmo painel funcional usado na visualiza��o/listagem.
- Runs manuais passam a usar o quadro manual compartilhado tamb�m no detalhe completo.
- Runs integradas passam a carregar via `/api/runs/kanban` no cliente, com loading, erro tratado e retry.
- A integra��o Qase agora tenta o fallback `/result` quando `/run/{project}/{runId}/cases` responde vazio.

## Por que

O resumo da run carregava, mas a �rea inferior continuava em um fluxo legado que inicializava o Kanban vazio ou engolia erro como lista vazia. Isso fazia aparecer `Cases n�o dispon�veis para este run` mesmo quando a run tinha totais.

## Valida��o

- `npx tsc --noEmit --pretty false`
- `npx eslint app/release/components/RunKanbanSection.tsx app/integrations/qase.ts app/empresas/[slug]/runs/RunDetailKanbanPanel.tsx app/components/RunCasesBoard.tsx`
