### PR TITLE
[codex] feat: finish structural quality block

### DIFF
--- a/__tests__/brain.test.ts
+++ b/__tests__/brain.test.ts
@@ -327,7 +327,7 @@ describe('Brain - Cérebro do Quality Control', () => {
         refId: 'hierarchy-app',
       })
 
-      const module = await upsertNode({
+      const moduleNode = await upsertNode({
         type: 'Module',
         label: 'Hierarchy Module',
         refType: 'Module',
@@ -335,7 +335,7 @@ describe('Brain - Cérebro do Quality Control', () => {
       })
 
       await connectNodes(company.id, app.id, 'HAS_APPLICATION')
-      await connectNodes(app.id, module.id, 'HAS_MODULE')
+      await connectNodes(app.id, moduleNode.id, 'HAS_MODULE')
 
       const context = await getNodeWithContext(company.id, 2)
 

--- a/app/clients/components/CreateClientModal.tsx
+++ b/app/clients/components/CreateClientModal.tsx
@@ -57,6 +57,23 @@ function uniqCodes(values: string[]) {
   return Array.from(new Set(values.map((value) => value.trim().toUpperCase()).filter(Boolean)));
 }
 
+function formatCep(value: string) {
+  const digits = value.replace(/\D/g, "").slice(0, 8);
+  return digits.length > 5 ? `${digits.slice(0, 5)}-${digits.slice(5)}` : digits;
+}
+
+function buildViaCepAddress(data: Record<string, unknown>) {
+  return [
+    typeof data.logradouro === "string" ? data.logradouro : "",
+    typeof data.bairro === "string" ? data.bairro : "",
+    typeof data.localidade === "string" ? data.localidade : "",
+    typeof data.uf === "string" ? data.uf : "",
+  ]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(", ");
+}
+
 export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientId }: Props) {
   const [name, setName] = useState("");
   const [taxId, setTaxId] = useState("");
@@ -98,13 +115,68 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
   const [error, setError] = useState<string | null>(null);
   const [createdClientId, setCreatedClientId] = useState<string | null>(clientId ?? null);
   const [loadingClient, setLoadingClient] = useState(false);
+  const [cepLoading, setCepLoading] = useState(false);
+  const [cepMessage, setCepMessage] = useState<string | null>(null);
+  const [addressTouched, setAddressTouched] = useState(false);
 
   const selectedProjects = useMemo(
     () => qaseProjects.filter((project) => selectedQaseProjectCodes.includes(project.code)),
     [qaseProjects, selectedQaseProjectCodes],
   );
 
-  if (!open) return null;
+  useEffect(() => {
+    if (!open) return;
+    const digits = zip.replace(/\D/g, "");
+    if (digits.length === 0) {
+      setCepMessage(null);
+      return;
+    }
+    if (digits.length < 8) {
+      setCepMessage("Digite os 8 digitos do CEP.");
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 8_000);
+
+    async function lookupCep() {
+      setCepLoading(true);
+      setCepMessage(null);
+      try {
+        const response = await fetch(`https://viacep.com.br/ws/${digits}/json/`, {
+          signal: controller.signal,
+          cache: "no-store",
+        });
+        const data = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+        if (!response.ok || !data || data.erro === true) {
+          setCepMessage("CEP nao encontrado.");
+          return;
+        }
+
+        const nextAddress = buildViaCepAddress(data);
+        if (nextAddress && (!address.trim() || !addressTouched)) {
+          setAddress(nextAddress);
+          setAddressTouched(false);
+        }
+        setCepMessage("Endereco preenchido pelo CEP.");
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          setCepMessage("Consulta de CEP demorou demais. Tente novamente.");
+          return;
+        }
+        setCepMessage("Nao foi possivel consultar o CEP agora.");
+      } finally {
+        window.clearTimeout(timeoutId);
+        setCepLoading(false);
+      }
+    }
+
+    void lookupCep();
+    return () => {
+      controller.abort();
+      window.clearTimeout(timeoutId);
+    };
+  }, [address, addressTouched, open, zip]);
 
   useEffect(() => {
     if (!clientId) return;
@@ -122,6 +194,7 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
         setTaxId((data.tax_id as string) ?? "");
         setZip((data.cep as string) ?? "");
         setAddress((data.address as string) ?? "");
+        setAddressTouched(false);
         setPhone((data.phone as string) ?? "");
         setWebsite((data.website as string) ?? "");
         setLogoUrl((data.logo_url as string) ?? "");
@@ -179,6 +252,7 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
     setTaxId("");
     setZip("");
     setAddress("");
+    setAddressTouched(false);
     setPhone("");
     setWebsite("");
     setLogoUrl("");
@@ -342,7 +416,7 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
         if (project.status === "valid" || project.status === "invalid") continue;
         try {
           // validate sequentially to avoid burst
-          // eslint-disable-next-line no-await-in-loop
+           
           const ok = await validateProjectCode(token, project.code);
           setQaseProjects((prev) => prev.map((p) => (p.code === project.code ? { ...p, status: ok ? "valid" : "invalid" } : p)));
         } catch {
@@ -494,6 +568,8 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
     }
   }
 
+  if (!open) return null;
+
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 px-3 py-4">
       <form
@@ -553,9 +629,14 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
             <input
               className="mt-1 w-full rounded-lg border border-(--tc-border) bg-(--tc-input-bg,#eef4ff) px-3 py-2 text-sm text-(--tc-text) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--tc-focus)"
               value={zip}
-              onChange={(e) => setZip(e.target.value)}
+              onChange={(e) => setZip(formatCep(e.target.value))}
               placeholder="00000-000"
+              inputMode="numeric"
+              aria-describedby="company-cep-feedback"
             />
+            <span id="company-cep-feedback" className="mt-1 block min-h-4 text-xs text-(--tc-text-muted)">
+              {cepLoading ? "Consultando CEP..." : cepMessage}
+            </span>
           </label>
 
           <label className="block text-sm md:col-span-2">
@@ -563,7 +644,10 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
             <input
               className="mt-1 w-full rounded-lg border border-(--tc-border) bg-(--tc-input-bg,#eef4ff) px-3 py-2 text-sm text-(--tc-text) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--tc-focus)"
               value={address}
-              onChange={(e) => setAddress(e.target.value)}
+              onChange={(e) => {
+                setAddressTouched(true);
+                setAddress(e.target.value);
+              }}
               placeholder="Rua, número, cidade"
             />
           </label>
@@ -643,7 +727,7 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
 
             <div className="mt-3">
               <p className="text-sm font-semibold text-(--tc-text)"><FiZap size={13} className="text-(--tc-accent,#ef0001)" /> Integração com Qase</p>
-              <p className="mt-1 text-xs text-(--tc-text-muted)">Informe o token da Qase (novo ou já salvo) e clique em "Buscar projetos" para carregar os projetos disponíveis. Selecione os projetos que deseja vincular — cada projeto selecionado será cadastrado como uma aplicação da empresa.</p>
+              <p className="mt-1 text-xs text-(--tc-text-muted)">Informe o token da Qase (novo ou já salvo) e clique em &quot;Buscar projetos&quot; para carregar os projetos disponíveis. Selecione os projetos que deseja vincular — cada projeto selecionado será cadastrado como uma aplicação da empresa.</p>
             </div>
 
             <div className="mt-4 space-y-4">
@@ -835,7 +919,7 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
                 ) : (
                   <div className="flex items-center gap-3 rounded-lg border border-dashed border-(--tc-accent)/30 bg-(--tc-accent-soft,rgba(239,0,1,0.03)) px-4 py-4 text-sm text-(--tc-text-muted)">
                     <FiSearch size={18} className="shrink-0 text-(--tc-accent,#ef0001) opacity-60" />
-                    <span>Informe o token e clique em "Buscar projetos" para selecionar as aplicações da empresa. Cada projeto da Qase será cadastrado como uma aplicação independente.</span>
+                    <span>Informe o token e clique em &quot;Buscar projetos&quot; para selecionar as aplicações da empresa. Cada projeto da Qase será cadastrado como uma aplicação independente.</span>
                   </div>
                 )}
               </div>
@@ -936,3 +1020,4 @@ export function CreateClientModal({ open, onClose, onCreate, onOpenUser, clientI
     </div>
   );
 }
+

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   FiAlertTriangle,
@@ -17,6 +17,9 @@ import {
   FiList,
   FiShield,
   FiCpu,
+  FiBookOpen,
+  FiMessageSquare,
+  FiStar,
   FiUserPlus,
   FiUsers,
   FiZap,
@@ -30,6 +33,7 @@ import { isInstitutionalCompanyAccount } from "@/lib/activeIdentity";
 
 const menuLogoEnv = process.env.NEXT_PUBLIC_MENU_LOGO || "";
 const debugSidebar = process.env.NEXT_PUBLIC_DEBUG_SIDEBAR === "true";
+const FAVORITES_STORAGE_KEY = "qc:sidebar:favorites:v1";
 
 type AppRole = "admin" | "client" | "user" | "technical_support";
 
@@ -50,6 +54,16 @@ type SidebarProps = {
 export default function Sidebar({ pathname, mobileOpen = false, onClose, mobilePanelId }: SidebarProps) {
   const router = useRouter();
   const prefetchedRoutesRef = useRef<Set<string>>(new Set());
+  const [favoriteHrefs, setFavoriteHrefs] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = localStorage.getItem(FAVORITES_STORAGE_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+      return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+    } catch {
+      return [];
+    }
+  });
   const { user, loading, visibility, normalizedUser } = usePermissionAccess();
   const logoSrc = useMemo(() => {
     const dbLogo = typeof user?.companyLogoUrl === "string" ? user.companyLogoUrl.trim() : "";
@@ -60,7 +74,13 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
   const { activeClientSlug } = useClientContext();
   const { t } = useI18n();
 
-  
+  useEffect(() => {
+    try {
+      localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(favoriteHrefs));
+    } catch {
+      /* ignore */
+    }
+  }, [favoriteHrefs]);
 
   const legacyUser = (user ?? null) as unknown as { is_global_admin?: boolean } | null;
 
@@ -161,6 +181,8 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
     { label: t("nav.accessRequests"), icon: FiUserPlus, href: "/admin/access-requests" },
     { label: t("nav.auditLogs"), icon: FiBell, href: "/admin/audit-logs" },
     { label: "Brain", icon: FiCpu, href: "/admin/brain" },
+    { label: "Documentacao", icon: FiBookOpen, href: "/documentacao" },
+    { label: "Conversas", icon: FiMessageSquare, href: "/conversas" },
   ], [t, adminRunsMenuLabel]);
 
   const supportNav: NavItem[] = useMemo(() => {
@@ -180,6 +202,8 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
             { label: companyRunsMenuLabel, icon: FiList, href: buildCompanyPathForAccess(companySlug, "runs", companyRouteInput) },
             { label: t("nav.defects"), icon: FiAlertTriangle, href: buildCompanyPathForAccess(companySlug, "defeitos", companyRouteInput) },
             { label: t("nav.support"), icon: FiColumns, href: buildCompanyPathForAccess(companySlug, "chamados", companyRouteInput) },
+            { label: "Documentacao", icon: FiBookOpen, href: "/documentacao" },
+            { label: "Conversas", icon: FiMessageSquare, href: "/conversas" },
           ]
         : [],
     [companyRouteInput, companySlug, companyRunsMenuLabel, t]
@@ -255,19 +279,34 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
     }
   }
 
-  const renderNavLinks = (isMobile = false) =>
-    visibleNavigation.map((item) => {
+  function toggleFavorite(href: string) {
+    setFavoriteHrefs((current) =>
+      current.includes(href) ? current.filter((item) => item !== href) : [...current, href],
+    );
+  }
+
+  const favoriteNavigation = useMemo(
+    () => favoriteHrefs
+      .map((href) => visibleNavigation.find((item) => item.href === href))
+      .filter((item): item is NavItem => Boolean(item)),
+    [favoriteHrefs, visibleNavigation],
+  );
+
+  const renderNavLinks = (isMobile = false, items = visibleNavigation) =>
+    items.map((item) => {
         const isActive =
           item.href === "/"
             ? pathname === "/"
             : pathname === item.href || pathname.startsWith(`${item.href}/`);
 
+        const isFavorite = favoriteHrefs.includes(item.href);
+
         return (
-          <Link
-            key={item.href}
-            href={item.href}
-            prefetch={false}
-            className={`group/link relative flex items-center h-10 w-full rounded-xl text-sm font-semibold transition-all duration-200 overflow-hidden min-w-0 sidebar-link ${
+          <div key={item.href} className="group/item relative flex items-center">
+            <Link
+              href={item.href}
+              prefetch={false}
+              className={`group/link relative flex items-center h-10 w-full rounded-xl text-sm font-semibold transition-all duration-200 overflow-hidden min-w-0 sidebar-link ${
               isMobile
                 ? "px-3 justify-start gap-3"
                 : "px-3 justify-start gap-3"
@@ -276,29 +315,41 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
                 ? "sidebar-link-state-active bg-white/12 ring-1 ring-white/16 shadow-[0_14px_30px_rgba(1,24,72,0.3)] text-white"
                 : "sidebar-link-state-idle text-white/74 hover:bg-white/8 hover:text-white"
             }`}
-            onMouseEnter={() => prefetchHref(item.href)}
-            onFocus={() => prefetchHref(item.href)}
-            onClick={isMobile && onClose ? onClose : undefined}
-          >
-            <span
-              aria-hidden
-              className={`absolute left-1 top-2 bottom-2 w-0.75 rounded-full bg-(--tc-accent,#ef0001) transition-all ${
-                isActive ? "opacity-100" : "opacity-0 group-hover/link:opacity-60"
-              }`}
-            />
-            <div
-              className={`flex items-center justify-center w-10 h-10 rounded-[14px] border transition-all duration-200 shrink-0 backdrop-blur-sm sidebar-icon ${
-                isActive
-                  ? "sidebar-icon-state-active border-white/16 bg-white/14 text-white shadow-[0_12px_26px_rgba(1,24,72,0.28)]"
-                  : "sidebar-icon-state-idle border-white/10 bg-white/6 text-white/84 group-hover/link:border-white/18 group-hover/link:bg-white/10 group-hover/link:text-white"
-              }`}
+              onMouseEnter={() => prefetchHref(item.href)}
+              onFocus={() => prefetchHref(item.href)}
+              onClick={isMobile && onClose ? onClose : undefined}
             >
-              <item.icon size={17} />
-            </div>
-            <span className="sidebar-label flex-1 overflow-hidden pl-3 text-left leading-snug truncate">
-              {item.label}
-            </span>
-          </Link>
+              <span
+                aria-hidden
+                className={`absolute left-1 top-2 bottom-2 w-0.75 rounded-full bg-(--tc-accent,#ef0001) transition-all ${
+                  isActive ? "opacity-100" : "opacity-0 group-hover/link:opacity-60"
+                }`}
+              />
+              <div
+                className={`flex items-center justify-center w-10 h-10 rounded-[14px] border transition-all duration-200 shrink-0 backdrop-blur-sm sidebar-icon ${
+                  isActive
+                    ? "sidebar-icon-state-active border-white/16 bg-white/14 text-white shadow-[0_12px_26px_rgba(1,24,72,0.28)]"
+                    : "sidebar-icon-state-idle border-white/10 bg-white/6 text-white/84 group-hover/link:border-white/18 group-hover/link:bg-white/10 group-hover/link:text-white"
+                }`}
+              >
+                <item.icon size={17} />
+              </div>
+              <span className="sidebar-label flex-1 overflow-hidden pl-3 pr-8 text-left leading-snug truncate">
+                {item.label}
+              </span>
+            </Link>
+            <button
+              type="button"
+              onClick={() => toggleFavorite(item.href)}
+              className={`absolute right-2 inline-flex h-7 w-7 items-center justify-center rounded-full transition ${
+                isFavorite ? "text-yellow-300 opacity-100" : "text-white/40 opacity-0 group-hover/item:opacity-100 focus:opacity-100"
+              }`}
+              aria-label={isFavorite ? `Remover ${item.label} dos favoritos` : `Adicionar ${item.label} aos favoritos`}
+              title={isFavorite ? "Remover dos favoritos" : "Favoritar"}
+            >
+              <FiStar className={isFavorite ? "fill-current" : ""} size={14} />
+            </button>
+          </div>
         );
       });
 
@@ -358,6 +409,12 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
               </p>
               <span className="h-px flex-1 ml-3 bg-white/12 sidebar-divider-line" aria-hidden />
             </div>
+            {favoriteNavigation.length > 0 ? (
+              <div className="mb-3 space-y-2 rounded-2xl border border-white/8 bg-white/5 p-2">
+                <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/50">Favoritos</p>
+                {renderNavLinks(false, favoriteNavigation)}
+              </div>
+            ) : null}
             <div className="space-y-2">{renderNavLinks()}</div>
           </div>
         </div>
@@ -424,6 +481,12 @@ export default function Sidebar({ pathname, mobileOpen = false, onClose, mobileP
             <div className="flex-1 px-3 py-3 space-y-3">
               <div className="space-y-2">
                 <p className="sidebar-nav-caption px-1 text-xs uppercase tracking-[0.18em] text-white/52">Navegacao</p>
+                {favoriteNavigation.length > 0 ? (
+                  <div className="mb-3 space-y-2 rounded-2xl border border-white/8 bg-white/5 p-2">
+                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/50">Favoritos</p>
+                    {renderNavLinks(true, favoriteNavigation)}
+                  </div>
+                ) : null}
                 <div className="space-y-2">{renderNavLinks(true)}</div>
               </div>
             </div>

--- a/app/conversas/page.tsx
+++ b/app/conversas/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { FiMessageSquare, FiPlus, FiSearch } from "react-icons/fi";
+
+type ConversationType = "decisao" | "incidente" | "release" | "automacao" | "ticket" | "sistema";
+
+type ConversationEvent = {
+  id: string;
+  type: ConversationType;
+  title: string;
+  message: string;
+  createdAt: string;
+};
+
+const STORAGE_KEY = "qc:internal-conversations:v1";
+
+const INITIAL_EVENTS: ConversationEvent[] = [
+  {
+    id: "runs-foundation",
+    type: "decisao",
+    title: "Runs antes de novas features",
+    message: "Prioridade operacional definida: estabilizar acesso por empresa e detalhe de runs antes de puxar novos modulos.",
+    createdAt: "2026-04-29T09:00:00.000Z",
+  },
+  {
+    id: "qase-kanban",
+    type: "incidente",
+    title: "Kanban integrado inconsistente",
+    message: "Resumo da run carregava, mas casos nao acompanhavam na tela completa. Fluxo passou a reutilizar painel compartilhado.",
+    createdAt: "2026-04-29T10:30:00.000Z",
+  },
+];
+
+const TYPES: Array<{ value: ConversationType | "todos"; label: string }> = [
+  { value: "todos", label: "Todos" },
+  { value: "decisao", label: "Decisao" },
+  { value: "incidente", label: "Incidente" },
+  { value: "release", label: "Release" },
+  { value: "automacao", label: "Automacao" },
+  { value: "ticket", label: "Ticket" },
+  { value: "sistema", label: "Sistema" },
+];
+
+export default function InternalConversationsPage() {
+  const [events, setEvents] = useState<ConversationEvent[]>(() => {
+    if (typeof window === "undefined") return INITIAL_EVENTS;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) return INITIAL_EVENTS;
+      const parsed = JSON.parse(stored) as ConversationEvent[];
+      return Array.isArray(parsed) ? parsed : INITIAL_EVENTS;
+    } catch {
+      return INITIAL_EVENTS;
+    }
+  });
+  const [filter, setFilter] = useState<ConversationType | "todos">("todos");
+  const [query, setQuery] = useState("");
+  const [draftType, setDraftType] = useState<ConversationType>("decisao");
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftMessage, setDraftMessage] = useState("");
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+    } catch {
+      /* ignore */
+    }
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return events
+      .filter((event) => filter === "todos" || event.type === filter)
+      .filter((event) => !needle || `${event.title} ${event.message} ${event.type}`.toLowerCase().includes(needle))
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  }, [events, filter, query]);
+
+  function addEvent() {
+    const title = draftTitle.trim();
+    const message = draftMessage.trim();
+    if (!title || !message) return;
+    setEvents((current) => [
+      {
+        id: crypto.randomUUID(),
+        type: draftType,
+        title,
+        message,
+        createdAt: new Date().toISOString(),
+      },
+      ...current,
+    ]);
+    setDraftTitle("");
+    setDraftMessage("");
+  }
+
+  return (
+    <main className="min-h-screen bg-(--tc-page-bg,#f5f7fb) px-4 py-6 text-(--tc-text,#0b1a3c) lg:px-8">
+      <section className="mx-auto grid max-w-7xl gap-5 lg:grid-cols-[380px_1fr]">
+        <aside className="rounded-[28px] border border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-5 shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[0.28em] text-(--tc-accent,#ef0001)">Operacao</p>
+          <h1 className="mt-2 text-2xl font-black">Conversa interna</h1>
+          <p className="mt-2 text-sm text-(--tc-text-muted,#64748b)">Registro local de decisoes, incidentes e contexto de retomada.</p>
+
+          <div className="mt-5 space-y-3">
+            <select value={draftType} onChange={(event) => setDraftType(event.target.value as ConversationType)} className="w-full rounded-2xl border border-(--tc-border,#dfe5f1) bg-(--tc-surface-2,#eef4ff) px-3 py-2 text-sm">
+              {TYPES.filter((type) => type.value !== "todos").map((type) => (
+                <option key={type.value} value={type.value}>{type.label}</option>
+              ))}
+            </select>
+            <input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} className="w-full rounded-2xl border border-(--tc-border,#dfe5f1) bg-(--tc-surface-2,#eef4ff) px-3 py-2 text-sm" placeholder="Titulo do registro" />
+            <textarea value={draftMessage} onChange={(event) => setDraftMessage(event.target.value)} className="min-h-32 w-full rounded-2xl border border-(--tc-border,#dfe5f1) bg-(--tc-surface-2,#eef4ff) px-3 py-2 text-sm" placeholder="Contexto, decisao ou proximo passo" />
+            <button type="button" onClick={addEvent} disabled={!draftTitle.trim() || !draftMessage.trim()} className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-(--tc-accent,#ef0001) px-4 py-3 text-sm font-bold text-white transition hover:opacity-90 disabled:opacity-50">
+              <FiPlus className="h-4 w-4" />
+              Registrar comentario
+            </button>
+          </div>
+        </aside>
+
+        <section className="space-y-4">
+          <div className="rounded-[24px] border border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-4 shadow-sm">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="relative w-full md:max-w-md">
+                <FiSearch className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-(--tc-text-muted,#64748b)" />
+                <input value={query} onChange={(event) => setQuery(event.target.value)} className="w-full rounded-2xl border border-(--tc-border,#dfe5f1) bg-(--tc-surface-2,#eef4ff) py-2.5 pr-4 pl-11 text-sm" placeholder="Buscar no historico" />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {TYPES.map((type) => (
+                  <button key={type.value} type="button" onClick={() => setFilter(type.value)} className={`rounded-full px-3 py-1.5 text-xs font-bold uppercase tracking-[0.16em] ${filter === type.value ? "bg-(--tc-accent,#ef0001) text-white" : "bg-(--tc-surface-2,#eef4ff) text-(--tc-text-secondary,#475569)"}`}>
+                    {type.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="rounded-[24px] border border-dashed border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-8 text-sm text-(--tc-text-muted,#64748b)">Nenhum registro encontrado.</div>
+          ) : (
+            filtered.map((event) => (
+              <article key={event.id} className="rounded-[24px] border border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-5 shadow-sm">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-(--tc-accent-soft,#fee2e2) px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-(--tc-accent,#ef0001)">
+                    <FiMessageSquare className="h-3.5 w-3.5" />
+                    {event.type}
+                  </span>
+                  <time className="text-xs text-(--tc-text-muted,#64748b)">{new Date(event.createdAt).toLocaleString("pt-BR")}</time>
+                </div>
+                <h2 className="mt-3 text-lg font-black">{event.title}</h2>
+                <p className="mt-2 text-sm leading-6 text-(--tc-text-secondary,#475569)">{event.message}</p>
+              </article>
+            ))
+          )}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/app/docs/DocsWikiClient.tsx
+++ b/app/docs/DocsWikiClient.tsx
@@ -1239,7 +1239,7 @@ export default function DocsWikiClient({ basePath = "/api/platform-docs" }: { ba
               ))}
               {editBlocks.length === 0 && (
                 <p className="text-xs text-[#9ca3af] text-center py-6 border border-dashed border-[#e5e7eb] rounded-lg">
-                  Clique em "Adicionar Bloco" para começar.
+                  Clique em &quot;Adicionar Bloco&quot; para começar.
                 </p>
               )}
             </div>
@@ -1359,3 +1359,4 @@ export default function DocsWikiClient({ basePath = "/api/platform-docs" }: { ba
     </div>
   );
 }
+

--- a/app/documentacao/page.tsx
+++ b/app/documentacao/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { FiBookOpen, FiSearch } from "react-icons/fi";
+import { documentationEntries } from "@/data/documentation";
+
+export default function DocumentationPage() {
+  const [query, setQuery] = useState("");
+  const [activeArea, setActiveArea] = useState<string>("Todas");
+  const areas = useMemo(() => ["Todas", ...Array.from(new Set(documentationEntries.map((entry) => entry.area)))], []);
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return documentationEntries.filter((entry) => {
+      const matchesArea = activeArea === "Todas" || entry.area === activeArea;
+      const haystack = `${entry.area} ${entry.title} ${entry.summary} ${entry.content}`.toLowerCase();
+      return matchesArea && (!needle || haystack.includes(needle));
+    });
+  }, [activeArea, query]);
+
+  return (
+    <main className="min-h-screen bg-(--tc-page-bg,#f5f7fb) px-4 py-6 text-(--tc-text,#0b1a3c) lg:px-8">
+      <section className="mx-auto max-w-7xl space-y-5">
+        <div className="rounded-[28px] bg-[linear-gradient(135deg,#071b49,#102f72_58%,#b60018)] p-6 text-white shadow-[0_24px_70px_rgba(15,23,42,0.2)]">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/60">Quality Control</p>
+              <h1 className="mt-2 text-3xl font-black">Documentacao viva</h1>
+              <p className="mt-2 max-w-3xl text-sm text-white/72">
+                Base interna para decisoes, fluxos, permissoes e retomada tecnica do produto.
+              </p>
+            </div>
+            <div className="relative w-full max-w-md">
+              <FiSearch className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-white/50" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                className="w-full rounded-2xl border border-white/16 bg-white/10 py-3 pr-4 pl-11 text-sm text-white placeholder:text-white/48 outline-none focus:ring-2 focus:ring-white/30"
+                placeholder="Buscar por titulo ou conteudo"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-[260px_1fr]">
+          <aside className="rounded-[24px] border border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-3 shadow-sm">
+            {areas.map((area) => (
+              <button
+                key={area}
+                type="button"
+                onClick={() => setActiveArea(area)}
+                className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left text-sm font-semibold transition ${
+                  activeArea === area ? "bg-(--tc-accent,#ef0001) text-white" : "text-(--tc-text,#0b1a3c) hover:bg-(--tc-surface-2,#eef4ff)"
+                }`}
+              >
+                <FiBookOpen className="h-4 w-4" />
+                {area}
+              </button>
+            ))}
+          </aside>
+
+          <section className="grid gap-4 md:grid-cols-2">
+            {filtered.length === 0 ? (
+              <div className="rounded-[24px] border border-dashed border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-8 text-sm text-(--tc-text-muted,#64748b) md:col-span-2">
+                Nenhum documento encontrado para a busca atual.
+              </div>
+            ) : (
+              filtered.map((entry) => (
+                <article key={entry.id} className="rounded-[24px] border border-(--tc-border,#dfe5f1) bg-(--tc-surface,#fff) p-5 shadow-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <span className="rounded-full bg-(--tc-accent-soft,#fee2e2) px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-(--tc-accent,#ef0001)">
+                      {entry.area}
+                    </span>
+                    <span className="text-xs text-(--tc-text-muted,#64748b)">{entry.updatedAt}</span>
+                  </div>
+                  <h2 className="mt-4 text-xl font-black">{entry.title}</h2>
+                  <p className="mt-2 text-sm font-semibold text-(--tc-text-secondary,#475569)">{entry.summary}</p>
+                  <p className="mt-4 text-sm leading-6 text-(--tc-text-muted,#64748b)">{entry.content}</p>
+                </article>
+              ))
+            )}
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/empresas/[slug]/home/CompanyRunsHomeClient.tsx
+++ b/app/empresas/[slug]/home/CompanyRunsHomeClient.tsx
@@ -681,7 +681,7 @@ export default function CompanyRunsHomeClient(props: CompanyRunsHomeClientProps)
           )}
           {hasMoreRunsThanCards ? (
             <p className="mt-4 text-xs font-medium text-(--tc-text-muted,#6b7280)">
-              Exibindo {runsForCards.length} de {runs.length} runs para leitura rápida. Use o botão "Abrir runs" para ver a lista completa.
+              Exibindo {runsForCards.length} de {runs.length} runs para leitura rápida. Use o botão &quot;Abrir runs&quot; para ver a lista completa.
             </p>
           ) : null}
         </section>
@@ -873,7 +873,7 @@ export default function CompanyRunsHomeClient(props: CompanyRunsHomeClientProps)
               <p className="text-sm font-semibold uppercase tracking-[0.24em] text-(--tc-text-muted,#6b7280)">Run em foco</p>
               <h3 className="mt-3 text-xl font-extrabold text-(--tc-text,#0b1a3c)">Selecione uma run para carregar o resumo detalhado</h3>
               <p className="mt-2 text-sm text-(--tc-text-secondary,#4b5563)">
-                Clique em "Ver resumo" em um card para abrir distribuição de casos, eventos e sinais de atenção.
+                Clique em &quot;Ver resumo&quot; em um card para abrir distribuição de casos, eventos e sinais de atenção.
               </p>
               <div className="mt-5">
                 <button
@@ -891,3 +891,4 @@ export default function CompanyRunsHomeClient(props: CompanyRunsHomeClientProps)
     </div>
   );
 }
+

--- a/data/documentation.ts
+++ b/data/documentation.ts
@@ -1,0 +1,93 @@
+export type DocumentationArea =
+  | "Runs"
+  | "Empresas"
+  | "Automacao"
+  | "API Lab"
+  | "Playwright"
+  | "Brain"
+  | "Permissoes"
+  | "Integracoes";
+
+export type DocumentationEntry = {
+  id: string;
+  area: DocumentationArea;
+  title: string;
+  summary: string;
+  content: string;
+  updatedAt: string;
+};
+
+export const documentationEntries: DocumentationEntry[] = [
+  {
+    id: "runs-base",
+    area: "Runs",
+    title: "Fluxo de Runs",
+    summary: "Como runs manuais e integradas entram no Quality Control.",
+    updatedAt: "2026-04-29",
+    content:
+      "Runs integradas carregam estatisticas e casos via Qase. Runs manuais usam o quadro local editavel, com status, evidencias e bugs sincronizados nos totais.",
+  },
+  {
+    id: "empresas-acesso",
+    area: "Empresas",
+    title: "Acesso por empresa",
+    summary: "Regras de vinculo, slug ativo e usuario privilegiado.",
+    updatedAt: "2026-04-29",
+    content:
+      "Rotas em /empresas/[slug] devem validar o usuario normalizado. Usuarios TC, suporte e administradores globais podem acessar empresas sem vinculo direto quando a regra do perfil permitir.",
+  },
+  {
+    id: "automacao-modulos",
+    area: "Automacao",
+    title: "Central de automacao",
+    summary: "Visao geral dos modulos de automacao ja existentes.",
+    updatedAt: "2026-04-29",
+    content:
+      "A area de automacoes concentra API Lab, Playwright Studio, execucoes, logs e workbench operacional. Novas automacoes devem reaproveitar esses modulos.",
+  },
+  {
+    id: "api-lab",
+    area: "API Lab",
+    title: "API Lab",
+    summary: "Uso do laboratorio de APIs para colecoes e validacoes.",
+    updatedAt: "2026-04-29",
+    content:
+      "O API Lab serve para organizar requisicoes, ambientes e validacoes. Ele deve evoluir sem duplicar logica de integracao ja presente em automacoes.",
+  },
+  {
+    id: "playwright",
+    area: "Playwright",
+    title: "Playwright Studio",
+    summary: "Execucao e organizacao de cenarios automatizados.",
+    updatedAt: "2026-04-29",
+    content:
+      "O Playwright Studio e a rota de Playwright ja existem. Use esses pontos para expandir cenarios, logs e evidencias de automacao.",
+  },
+  {
+    id: "brain",
+    area: "Brain",
+    title: "Brain operacional",
+    summary: "Memoria e apoio operacional para o painel.",
+    updatedAt: "2026-04-29",
+    content:
+      "O Brain deve apoiar analise, historico e retomada tecnica, sempre conectado aos fluxos reais do Quality Control.",
+  },
+  {
+    id: "permissoes",
+    area: "Permissoes",
+    title: "Permissoes e capacidades",
+    summary: "Como roles e capabilities impactam navegacao e acesso.",
+    updatedAt: "2026-04-29",
+    content:
+      "A navegacao e os guards devem consultar roles normalizadas e capabilities. Evite validar acesso diretamente contra campos crus do payload.",
+  },
+  {
+    id: "integracoes",
+    area: "Integracoes",
+    title: "Integracoes externas",
+    summary: "Qase, Jira e demais fontes externas.",
+    updatedAt: "2026-04-29",
+    content:
+      "Integracoes devem ter erro tratado e fallback visivel. Dados externos nao devem bloquear a renderizacao basica do shell da empresa.",
+  },
+];

--- a/lib/auth/normalizeAuthenticatedUser.ts
+++ b/lib/auth/normalizeAuthenticatedUser.ts
@@ -7,7 +7,13 @@ export type AuthenticatedUserLike = Partial<AuthUser> &
   UnknownRecord & {
     companySlug?: string | null;
     companySlugs?: string[] | null;
+    company_slug?: string | null;
+    client_slug?: string | null;
+    defaultClientSlug?: string | null;
     default_company_slug?: string | null;
+    defaultCompanySlug?: string | null;
+    primaryCompanySlug?: string | null;
+    activeClientSlug?: string | null;
     roleNames?: unknown;
     companies?: unknown;
     clients?: unknown;
@@ -25,6 +31,7 @@ export type NormalizedAuthenticatedCompany = {
   id?: string;
   slug: string;
   name?: string;
+  role?: string | null;
 };
 
 export type NormalizedAuthenticatedUser = {
@@ -76,9 +83,11 @@ function normalizeCompanyRecord(value: unknown): NormalizedAuthenticatedCompany 
   const normalized: NormalizedAuthenticatedCompany = { slug };
   const id = readString(value.id ?? value.clientId ?? value.companyId ?? value.client_id ?? value.company_id);
   const name = readString(value.name ?? value.company_name ?? value.companyName ?? value.label ?? value.title);
+  const role = readString(value.role ?? value.companyRole ?? value.permissionRole ?? value.accessRole);
 
   if (id) normalized.id = id;
   if (name) normalized.name = name;
+  if (role) normalized.role = role;
   return normalized;
 }
 
@@ -95,6 +104,7 @@ function collectCompanyCandidates(value: unknown): NormalizedAuthenticatedCompan
       ...(company.id ? { id: company.id } : {}),
       slug,
       ...(company.name ? { name: company.name } : {}),
+      ...(company.role ? { role: company.role } : {}),
     });
   };
 
@@ -112,7 +122,7 @@ function collectCompanyCandidates(value: unknown): NormalizedAuthenticatedCompan
 
     add(normalizeCompanyRecord(candidate));
 
-    for (const key of ["company", "client", "tenant", "organization"]) {
+    for (const key of ["company", "client", "companies", "clients", "tenant", "organization", "organizations"]) {
       if (key in candidate) visit(candidate[key]);
     }
   };
@@ -192,6 +202,7 @@ function mergeCompanyCollections(...collections: NormalizedAuthenticatedCompany[
         ...(company.id ? { id: company.id } : {}),
         slug,
         ...(company.name ? { name: company.name } : {}),
+        ...(company.role ? { role: company.role } : {}),
       });
     }
   }
@@ -214,9 +225,14 @@ export function normalizeAuthenticatedUser(
 
   const companiesFromUser = mergeCompanyCollections(
     collectCompanyCandidates(raw.companySlug),
+    collectCompanyCandidates(raw.company_slug),
     collectCompanyCandidates(raw.clientSlug),
+    collectCompanyCandidates(raw.client_slug),
     collectCompanyCandidates(raw.defaultClientSlug),
+    collectCompanyCandidates(raw.defaultCompanySlug),
     collectCompanyCandidates(raw.default_company_slug),
+    collectCompanyCandidates(raw.primaryCompanySlug),
+    collectCompanyCandidates(raw.activeClientSlug),
     collectCompanyCandidates(raw.companySlugs),
     collectCompanyCandidates(raw.clientSlugs),
     collectCompanyCandidates(raw.companies),
@@ -226,6 +242,9 @@ export function normalizeAuthenticatedUser(
     collectCompanyCandidates(raw.tenant),
     collectCompanyCandidates(raw.organization),
     collectCompanyCandidates(raw.organizations),
+    collectCompanyCandidates(raw.permissions),
+    collectCompanyCandidates(raw.permissionKeys),
+    collectCompanyCandidates(raw.capabilities),
   );
 
   const normalizedCompanies = mergeCompanyCollections(companiesFromResponse.filter((value): value is NormalizedAuthenticatedCompany => Boolean(value)), companiesFromUser);
@@ -233,9 +252,14 @@ export function normalizeAuthenticatedUser(
   const directCompanySlugs = uniqueStrings(
     [
       normalizeSlug(raw.clientSlug),
+      normalizeSlug(raw.client_slug),
       normalizeSlug(raw.companySlug),
+      normalizeSlug(raw.company_slug),
+      normalizeSlug(raw.primaryCompanySlug),
       normalizeSlug(raw.defaultClientSlug),
+      normalizeSlug(raw.defaultCompanySlug),
       normalizeSlug(raw.default_company_slug),
+      normalizeSlug(raw.activeClientSlug),
     ].filter((value): value is string => Boolean(value)),
   );
   const companySlugs = uniqueStrings([
@@ -259,8 +283,18 @@ export function normalizeAuthenticatedUser(
     ...collectPermissionCandidates(raw.permissionKeys),
   ]);
 
-  const defaultCompanySlug = normalizeSlug(raw.defaultClientSlug) ?? normalizeSlug(raw.default_company_slug) ?? null;
-  const primaryCompanySlug = companySlugs[0] ?? normalizedCompanies[0]?.slug ?? defaultCompanySlug ?? null;
+  const defaultCompanySlug =
+    normalizeSlug(raw.defaultCompanySlug) ??
+    normalizeSlug(raw.defaultClientSlug) ??
+    normalizeSlug(raw.default_company_slug) ??
+    normalizeSlug(raw.activeClientSlug) ??
+    null;
+  const primaryCompanySlug =
+    normalizeSlug(raw.primaryCompanySlug) ??
+    companySlugs[0] ??
+    normalizedCompanies[0]?.slug ??
+    defaultCompanySlug ??
+    null;
 
   return {
     companySlugs,

--- a/lib/core/auth/RequireClient.tsx
+++ b/lib/core/auth/RequireClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { AuthSkeleton } from "@/components/AuthSkeleton";
 import { useAuthUser } from "@/hooks/useAuthUser";
@@ -13,13 +13,33 @@ type RequireClientProps = {
   fallback?: ReactNode;
 };
 
+const CLIENT_ACCESS_TIMEOUT_MS = 10_000;
+
 export function RequireClient({ slug, children, fallback }: RequireClientProps) {
   const { user, companies, loading, error, refreshUser } = useAuthUser();
   const router = useRouter();
   const pathname = usePathname() || "/";
+  const [validationTimedOut, setValidationTimedOut] = useState(false);
   const loginHref =
     pathname.startsWith("/") && pathname !== "/login" ? `/login?next=${encodeURIComponent(pathname)}` : "/login";
-  const access = resolveCompanyAccess({ user, companies, slug, loading, error });
+  const access = resolveCompanyAccess({
+    user,
+    companies,
+    slug,
+    loading: loading && !validationTimedOut,
+    error: validationTimedOut ? "A validacao de acesso demorou mais que o esperado." : error,
+  });
+
+  useEffect(() => {
+    if (!loading) {
+      const resetId = window.setTimeout(() => setValidationTimedOut(false), 0);
+      return () => window.clearTimeout(resetId);
+    }
+    const timeoutId = window.setTimeout(() => {
+      setValidationTimedOut(true);
+    }, CLIENT_ACCESS_TIMEOUT_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [loading]);
 
   useEffect(() => {
     if (access.status !== "unauthenticated") return;
@@ -33,20 +53,30 @@ export function RequireClient({ slug, children, fallback }: RequireClientProps) 
   }
 
   if (access.status === "error") {
+    const isTimeout = validationTimedOut && loading;
     return (
       <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-900">
-        <h2 className="text-lg font-semibold">Nao foi possivel validar a sessao</h2>
-        <p className="mt-2 text-sm text-red-700">{access.errorMessage ?? "Tente novamente em instantes."}</p>
+        <h2 className="text-lg font-semibold">
+          {isTimeout ? "Validacao demorou demais" : "Nao foi possivel validar a sessao"}
+        </h2>
+        <p className="mt-2 text-sm text-red-700">
+          {isTimeout
+            ? "A sessao ou o vinculo da empresa nao respondeu a tempo. Tente recarregar a validacao."
+            : access.errorMessage ?? "Tente novamente em instantes."}
+        </p>
         <div className="mt-4 flex flex-wrap gap-3">
           <button
             type="button"
-            onClick={() => void refreshUser(true)}
+            onClick={() => {
+              setValidationTimedOut(false);
+              void refreshUser(true);
+            }}
             className="rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700"
           >
             Tentar novamente
           </button>
           <Link
-            href="/login"
+            href={loginHref}
             className="rounded-xl border border-red-300 bg-white px-4 py-2 text-sm font-semibold text-red-800 transition hover:bg-red-100"
           >
             Ir para login

--- a/tests/RequireClient.test.tsx
+++ b/tests/RequireClient.test.tsx
@@ -2,7 +2,7 @@
 
 import "@testing-library/jest-dom";
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { RequireClient } from "@/components/RequireClient";
 
 const replaceMock = jest.fn();
@@ -36,6 +36,7 @@ jest.mock("@/hooks/useAuthUser", () => ({
 
 describe("RequireClient", () => {
   beforeEach(() => {
+    jest.useRealTimers();
     replaceMock.mockClear();
     refreshUserMock.mockClear();
     authState = {
@@ -151,6 +152,27 @@ describe("RequireClient", () => {
 
     expect(screen.getByText("Empresa nao encontrada")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Voltar para empresas" })).toHaveAttribute("href", "/empresas");
+  });
+
+  it("sai do loading infinito por timeout e permite tentar novamente", () => {
+    jest.useFakeTimers();
+    authState.loading = true;
+
+    render(
+      <RequireClient slug="griaule">
+        <div>conteudo protegido</div>
+      </RequireClient>,
+    );
+
+    expect(screen.getByText("Validando acesso da empresa")).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByText("Validacao demorou demais")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    expect(refreshUserMock).toHaveBeenCalledWith(true);
+    jest.useRealTimers();
   });
 
   it("redireciona para login quando nao existe usuario autenticado", async () => {

--- a/tests/normalizeAuthenticatedUser.test.ts
+++ b/tests/normalizeAuthenticatedUser.test.ts
@@ -12,7 +12,7 @@ describe("normalizeAuthenticatedUser", () => {
         Reports: ["VIEW", "Edit"],
         profile: ["READ"],
       },
-    } as Parameters<typeof normalizeAuthenticatedUser>[0]);
+    } as unknown as Parameters<typeof normalizeAuthenticatedUser>[0]);
 
     expect(normalized.companySlugs).toEqual(["griaule", "acme"]);
     expect(normalized.primaryCompanySlug).toBe("griaule");
@@ -78,11 +78,44 @@ describe("normalizeAuthenticatedUser", () => {
     const normalized = normalizeAuthenticatedUser({
       id: "user-legacy-company-slug",
       companySlug: "Griaule",
-    } as Parameters<typeof normalizeAuthenticatedUser>[0]);
+    } as unknown as Parameters<typeof normalizeAuthenticatedUser>[0]);
 
     expect(normalized.companySlugs).toEqual(["griaule"]);
     expect(normalized.primaryCompanySlug).toBe("griaule");
     expect(normalized.defaultCompanySlug).toBeNull();
+  });
+
+  it("normaliza campos snake_case, primary/default e activeClientSlug", () => {
+    const normalized = normalizeAuthenticatedUser({
+      id: "user-company-variants",
+      company_slug: " Griaule ",
+      client_slug: "ACME",
+      primaryCompanySlug: "GRIAULE",
+      defaultCompanySlug: "Beta",
+      activeClientSlug: "Gamma",
+    } as Parameters<typeof normalizeAuthenticatedUser>[0]);
+
+    expect(normalized.companySlugs).toEqual(["acme", "griaule", "beta", "gamma"]);
+    expect(normalized.primaryCompanySlug).toBe("griaule");
+    expect(normalized.defaultCompanySlug).toBe("beta");
+  });
+
+  it("extrai empresas de permissoes quando o vinculo vem aninhado", () => {
+    const normalized = normalizeAuthenticatedUser({
+      id: "user-permission-company",
+      permissions: {
+        companies: [{ slug: "Griaule", name: "Griaule", role: "qa" }],
+      },
+    } as unknown as Parameters<typeof normalizeAuthenticatedUser>[0]);
+
+    expect(normalized.companySlugs).toContain("griaule");
+    expect(normalized.companies).toEqual([
+      {
+        slug: "griaule",
+        name: "Griaule",
+        role: "qa",
+      },
+    ]);
   });
 });
 
@@ -132,6 +165,42 @@ describe("resolveCompanyAccess", () => {
 
     expect(access.status).toBe("allowed");
     expect(access.normalizedUser?.companySlugs).toEqual(["griaule"]);
+  });
+
+  it("permite acesso com companies contendo griaule", () => {
+    const access = resolveCompanyAccess({
+      user: { id: "user-company-array", companies: [{ slug: "Griaule" }] } as Parameters<typeof normalizeAuthenticatedUser>[0],
+      companies: [],
+      slug: "griaule",
+      loading: false,
+      error: null,
+    });
+
+    expect(access.status).toBe("allowed");
+  });
+
+  it("permite acesso com clients contendo griaule", () => {
+    const access = resolveCompanyAccess({
+      user: { id: "user-client-array", clients: [{ slug: "Griaule" }] } as Parameters<typeof normalizeAuthenticatedUser>[0],
+      companies: [],
+      slug: "griaule",
+      loading: false,
+      error: null,
+    });
+
+    expect(access.status).toBe("allowed");
+  });
+
+  it("permite acesso quando companies vem vazio mas defaultCompanySlug esta preenchido", () => {
+    const access = resolveCompanyAccess({
+      user: { id: "user-default-company", companies: [], defaultCompanySlug: "Griaule" } as Parameters<typeof normalizeAuthenticatedUser>[0],
+      companies: [],
+      slug: "griaule",
+      loading: false,
+      error: null,
+    });
+
+    expect(access.status).toBe("allowed");
   });
 
   it("permite acesso para usuario privilegiado mesmo sem match direto", () => {


### PR DESCRIPTION
## O que mudou

- Finaliza a normalizacao de vinculos de empresa no usuario autenticado.
- Fortalece o `RequireClient` com timeout, mensagens tratadas e retry.
- Adiciona testes para formatos legados de empresa e timeout do guard.
- Adiciona preenchimento de endereco por CEP via ViaCEP no modal de empresa.
- Cria a central de documentacao viva em `/documentacao` com dados locais tipados.
- Cria a central de conversa/historico operacional em `/conversas` com persistencia local.
- Evolui o menu lateral com atalhos para documentacao/conversas e favoritos persistidos.
- Corrige pequenos blockers de lint existentes em testes/docs/home.

## Tickets cobertos

- QUA-181
- QUA-182
- QUA-183
- QUA-180
- QUA-184
- QUA-185
- QUA-187 como checklist de estabilizacao

## Validacao

- `npx jest --config jest.config.ts --runInBand tests/normalizeAuthenticatedUser.test.ts tests/RequireClient.test.tsx`
- `npx tsc --noEmit --pretty false`
- `npm run lint` passou com warnings existentes do projeto
- `npm run build`

## Observacao

`npm test` completo executou 53 suites com sucesso e ficou com 2 timeouts em `tests/assistant/service.test.ts`, aparentando pendencia/flakiness fora do escopo tocado. Os testes focados de auth/guard passaram.
