### PR TITLE
feat: auto preencher cadastro de empresa por CNPJ (BrasilAPI)

### DIFF
--- a/app/components/CreateCompanyForm.tsx
+++ b/app/components/CreateCompanyForm.tsx
@@ -1,12 +1,48 @@
 "use client";
 import { useState } from "react";
 
+type BrasilApiCnpjResponse = {
+  razao_social?: string;
+  nome_fantasia?: string;
+};
+
+function normalizeCnpj(value: string) {
+  return value.replace(/\D/g, "").slice(0, 14);
+}
+
 export default function CreateCompanyForm({ onCreated }: { onCreated?: () => void }) {
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [cnpj, setCnpj] = useState("");
   const [loading, setLoading] = useState(false);
+  const [loadingCnpj, setLoadingCnpj] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+
+  async function handleCnpjBlur() {
+    const rawCnpj = normalizeCnpj(cnpj);
+
+    if (rawCnpj.length !== 14) return;
+
+    setLoadingCnpj(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`https://brasilapi.com.br/api/cnpj/v1/${rawCnpj}`);
+      if (!res.ok) throw new Error("CNPJ não encontrado");
+
+      const data = (await res.json()) as BrasilApiCnpjResponse;
+      const companyName = (data.nome_fantasia || data.razao_social || "").trim();
+
+      if (companyName && !name.trim()) {
+        setName(companyName);
+      }
+    } catch {
+      setError("Não foi possível buscar os dados da empresa pelo CNPJ");
+    } finally {
+      setLoadingCnpj(false);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -22,6 +58,7 @@ export default function CreateCompanyForm({ onCreated }: { onCreated?: () => voi
       if (!res.ok) throw new Error("Erro ao criar empresa");
       setName("");
       setSlug("");
+      setCnpj("");
       setSuccess(true);
       if (onCreated) onCreated();
     } catch {
@@ -34,6 +71,14 @@ export default function CreateCompanyForm({ onCreated }: { onCreated?: () => voi
   return (
     <form onSubmit={handleSubmit} className="max-w-md mx-auto p-4 space-y-2">
       <h2 className="text-lg font-bold mb-2">Criar nova empresa</h2>
+      <input
+        className="form-control-user border rounded px-2 py-1 w-full"
+        placeholder="CNPJ (opcional para preenchimento automático)"
+        value={cnpj}
+        onChange={e => setCnpj(normalizeCnpj(e.target.value))}
+        onBlur={handleCnpjBlur}
+      />
+      {loadingCnpj && <div className="text-sm text-gray-600">Consultando BrasilAPI...</div>}
       <input
         className="form-control-user border rounded px-2 py-1 w-full"
         placeholder="Nome da empresa"
@@ -51,7 +96,7 @@ export default function CreateCompanyForm({ onCreated }: { onCreated?: () => voi
       <button
         type="submit"
         className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
-        disabled={loading || !name || !slug}
+        disabled={loading || loadingCnpj || !name || !slug}
       >
         {loading ? "Salvando..." : "Criar Empresa"}
       </button>


### PR DESCRIPTION
### Motivation
- Reduzir a digitação manual no cadastro de empresas e acelerar o fluxo de criação.
- Melhorar a consistência dos dados preenchendo o nome da empresa a partir do CNPJ oficial quando disponível.

### Description
- Adicionado campo de CNPJ ao formulário em `app/components/CreateCompanyForm.tsx` com normalização via `normalizeCnpj`.
- Implementada consulta à `https://brasilapi.com.br/api/cnpj/v1/{cnpj}` ao sair do campo CNPJ na função `handleCnpjBlur` e preenchimento automático do nome usando `nome_fantasia` com fallback para `razao_social` quando o campo nome estiver vazio.
- Adicionado estado de carregamento (`loadingCnpj`) e mensagem de erro específica para falhas na consulta, e o botão de envio é desabilitado enquanto a consulta estiver em andamento.
- Mantido o fluxo de criação via endpoint interno `POST /api/company` sem alterações no backend e o campo CNPJ é limpo após criação bem-sucedida.

### Testing
- Executado lint no arquivo alterado com `npx eslint app/components/CreateCompanyForm.tsx` e sem erros de lint detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ade7a8c83309576e907db4e6108)