### PR TITLE
fix: address Sonar sort comparators

### DIFF
--- a/app/admin/brain/BrainGraphView.tsx
+++ b/app/admin/brain/BrainGraphView.tsx
@@ -617,7 +617,9 @@ export default function BrainGraphView() {
   );
 
   // Node types present for filter buttons
-  const nodeTypes = Array.from(new Set(nodes.map((n) => n.type))).sort();
+  const nodeTypes = Array.from(new Set(nodes.map((n) => n.type))).sort((left, right) =>
+    left.localeCompare(right),
+  );
 
   // Selected node context
   const selectedNode = nodes.find((n) => n.id === selectedNodeId);

--- a/app/admin/brain/BrainReactFlowView.tsx
+++ b/app/admin/brain/BrainReactFlowView.tsx
@@ -332,6 +332,22 @@ export default function BrainReactFlowView() {
     ]);
   }, []);
 
+  const runCommand = useCallback(
+    (rawInput: string, confirmed = false) => {
+      submitCommand(rawInput, confirmed).catch((error) => {
+        setCommandLog((current) => [
+          ...current,
+          {
+            id: `${Date.now()}-${Math.random()}`,
+            role: "system",
+            text: error instanceof Error ? error.message : "Falha ao executar comando.",
+          },
+        ]);
+      });
+    },
+    [submitCommand],
+  );
+
   const visibleNodesSorted = useMemo(
     () => [...filteredNodes].sort((a, b) => a.label.localeCompare(b.label)),
     [filteredNodes],
@@ -591,7 +607,7 @@ export default function BrainReactFlowView() {
                     onKeyDown={(event) => {
                       if (event.key === "Enter") {
                         event.preventDefault();
-                        void submitCommand(commandInput);
+                        runCommand(commandInput);
                         setCommandInput("");
                       }
                     }}
@@ -601,7 +617,7 @@ export default function BrainReactFlowView() {
                   <button
                     type="button"
                     onClick={() => {
-                      void submitCommand(commandInput);
+                      runCommand(commandInput);
                       setCommandInput("");
                     }}
                     className="rounded-lg bg-[#011848] px-3 text-xs font-semibold text-white"
@@ -612,7 +628,7 @@ export default function BrainReactFlowView() {
                 {awaitingConfirmation ? (
                   <button
                     type="button"
-                    onClick={() => void submitCommand(awaitingConfirmation.command, true)}
+                    onClick={() => runCommand(awaitingConfirmation.command, true)}
                     className="mt-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800"
                   >
                     Confirmar comando pendente

--- a/app/admin/brain/BrainReactFlowView.tsx
+++ b/app/admin/brain/BrainReactFlowView.tsx
@@ -204,7 +204,9 @@ export default function BrainReactFlowView() {
   );
 
   const typeOptions = useMemo(() => {
-    const types = Array.from(new Set(nodesApi.map((node) => node.type))).sort();
+    const types = Array.from(new Set(nodesApi.map((node) => node.type))).sort((left, right) =>
+      left.localeCompare(right),
+    );
     return ["all", ...types];
   }, [nodesApi]);
 

--- a/app/admin/clients/page.tsx
+++ b/app/admin/clients/page.tsx
@@ -726,17 +726,25 @@ export default function AdminConsolidatedPage() {
     }
   }, [router]);
 
+  const loadCurrentTab = useCallback(() => {
+    const loader = mainTab === "companies" ? loadCompanies : loadUsers;
+    loader().catch((error) => {
+      const message = error instanceof Error ? error.message : "Não foi possível carregar os dados.";
+      if (mainTab === "companies") {
+        setCompaniesMessage(message);
+      } else {
+        setUsersError(message);
+      }
+    });
+  }, [loadCompanies, loadUsers, mainTab]);
+
   // ========================================================================
   // INITIAL LOAD
   // ========================================================================
 
   useEffect(() => {
-    if (mainTab === "companies") {
-      void loadCompanies();
-    } else {
-      void loadUsers();
-    }
-  }, [mainTab, loadCompanies, loadUsers]);
+    loadCurrentTab();
+  }, [loadCurrentTab]);
 
   // ========================================================================
   // COMPANIES TAB COMPUTED VALUES

--- a/app/admin/defeitos/page.tsx
+++ b/app/admin/defeitos/page.tsx
@@ -491,7 +491,7 @@ export default function AdminDefeitosPage() {
                         )}
                         {d.origin === "manual" && (
                           <span className="rounded-full border border-amber-400/60 bg-amber-50 px-2 py-0.5 text-amber-700">
-                            {isPt ? "Manual" : "Manual"}
+                            Manual
                           </span>
                         )}
                       </div>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -323,9 +323,18 @@ export default function AdminUsersPage() {
     }
   }, [router]);
 
-  useEffect(() => {
-    void load();
+  const loadUsersAndCompanies = useCallback(() => {
+    load().catch((err) => {
+      setUsers([]);
+      setCompanies([]);
+      setError(err instanceof Error ? err.message : "Não foi possível carregar os usuários.");
+      setLoading(false);
+    });
   }, [load]);
+
+  useEffect(() => {
+    loadUsersAndCompanies();
+  }, [loadUsersAndCompanies]);
 
 
   const sortUsers = useCallback(

--- a/app/api/admin/audit-logs/route.ts
+++ b/app/api/admin/audit-logs/route.ts
@@ -60,26 +60,37 @@ const RESULT_CATEGORIES: Record<ResultFilter, ActionCategory[]> = {
   warning: ["delete"],
 };
 
+const CATEGORY_KEYWORDS: Array<{ category: ActionCategory; keywords: string[] }> = [
+  { category: "error", keywords: ["failure", "fail", "system.error", "denied", "error"] },
+  { category: "auth", keywords: ["login", "logout", "auth", "password"] },
+  { category: "export", keywords: ["export"] },
+  { category: "link", keywords: ["request.", "access_request", "link", "unlink", "membership"] },
+  { category: "integration", keywords: ["integration", "sync"] },
+  { category: "permission", keywords: ["permission", "role", "activated", "deactivated"] },
+];
+
+function hasAnyKeyword(value: string, keywords: string[]) {
+  return keywords.some((keyword) => value.includes(keyword));
+}
+
+function getTicketOrDefectCategory(value: string): ActionCategory | null {
+  if (!hasAnyKeyword(value, ["ticket", "defect"])) return null;
+  if (value.includes("create")) return "create";
+  if (hasAnyKeyword(value, ["delete", "closed"])) return "delete";
+  return "update";
+}
+
 function getCategory(action: string): ActionCategory {
   const value = action.toLowerCase();
-  if (value.includes("failure") || value.includes("fail") || value.includes("system.error") || value.includes("denied")) {
-    return "error";
-  }
-  if (value.includes("error")) return "error";
-  if (value.includes("login") || value.includes("logout") || value.includes("auth") || value.includes("password")) return "auth";
-  if (value.includes("export")) return "export";
-  if (value.includes("request.") || value.includes("access_request")) return "link";
-  if (value.includes("link") || value.includes("unlink") || value.includes("membership")) return "link";
-  if (value.includes("integration") || value.includes("sync")) return "integration";
-  if (value.includes("permission") || value.includes("role") || value.includes("activated") || value.includes("deactivated")) return "permission";
-  if (value.includes("ticket") || value.includes("defect")) {
-    if (value.includes("create")) return "create";
-    if (value.includes("delete") || value.includes("closed")) return "delete";
-    return "update";
-  }
+  const keywordMatch = CATEGORY_KEYWORDS.find((rule) => hasAnyKeyword(value, rule.keywords));
+  if (keywordMatch) return keywordMatch.category;
+
+  const ticketOrDefectCategory = getTicketOrDefectCategory(value);
+  if (ticketOrDefectCategory) return ticketOrDefectCategory;
+
   if (value.includes("create")) return "create";
-  if (value.includes("update") || value.includes("changed") || value.includes("logo") || value.includes("avatar") || value.includes("profile")) return "update";
-  if (value.includes("delete") || value.includes("removed")) return "delete";
+  if (hasAnyKeyword(value, ["update", "changed", "logo", "avatar", "profile"])) return "update";
+  if (hasAnyKeyword(value, ["delete", "removed"])) return "delete";
   return "default";
 }
 

--- a/app/api/admin/qase/projects/validate/route.ts
+++ b/app/api/admin/qase/projects/validate/route.ts
@@ -6,36 +6,50 @@ import { requireGlobalAdminWithStatus } from "@/lib/rbac/requireGlobalAdmin";
 
 export const runtime = "nodejs";
 
+async function parseValidationRequest(req: NextRequest) {
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  return {
+    requestedToken: typeof body?.token === "string" ? body.token.trim() : "",
+    requestedSlug: typeof body?.companySlug === "string" ? body.companySlug.trim().toLowerCase() : "",
+    projectCode: typeof body?.code === "string" ? body.code.trim().toUpperCase() : "",
+    requestedBaseUrl: typeof body?.baseUrl === "string" ? body.baseUrl.trim() : "",
+  };
+}
+
+async function resolveQaseCredentials(input: Awaited<ReturnType<typeof parseValidationRequest>>) {
+  const settings = !input.requestedToken && input.requestedSlug ? await getClientQaseSettings(input.requestedSlug) : null;
+  return {
+    token: input.requestedToken || settings?.token || "",
+    baseUrl: input.requestedBaseUrl || settings?.baseUrl || process.env.QASE_BASE_URL || "https://api.qase.io",
+  };
+}
+
+function validationErrorResponse(err: unknown) {
+  const statusCode = err instanceof QaseError ? err.status : 500;
+  if (statusCode === 404) return NextResponse.json({ valid: false, error: "Projeto não encontrado" }, { status: 404 });
+  if (statusCode === 401 || statusCode === 403) return NextResponse.json({ valid: false, error: "Token invalido ou sem acesso" }, { status: statusCode });
+  return NextResponse.json({ valid: false, error: "Erro ao validar projeto" }, { status: statusCode });
+}
+
 export async function POST(req: NextRequest) {
   const { admin, status } = await requireGlobalAdminWithStatus(req);
   if (!admin) return NextResponse.json({ error: "Sem permissão" }, { status });
 
-  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
-  const requestedToken = typeof body?.token === "string" ? body.token.trim() : "";
-  const requestedSlug = typeof body?.companySlug === "string" ? body.companySlug.trim().toLowerCase() : "";
-  const projectCode = typeof body?.code === "string" ? body.code.trim().toUpperCase() : "";
-  const requestedBaseUrl = typeof body?.baseUrl === "string" ? body.baseUrl.trim() : "";
+  const request = await parseValidationRequest(req);
+  if (!request.projectCode) return NextResponse.json({ error: "Informe o codigo do projeto a validar." }, { status: 400 });
 
-  if (!projectCode) return NextResponse.json({ error: "Informe o codigo do projeto a validar." }, { status: 400 });
-
-  const settings = !requestedToken && requestedSlug ? await getClientQaseSettings(requestedSlug) : null;
-  const token = requestedToken || settings?.token || "";
-  const baseUrl = requestedBaseUrl || settings?.baseUrl || process.env.QASE_BASE_URL || "https://api.qase.io";
-
+  const { token, baseUrl } = await resolveQaseCredentials(request);
   if (!token) return NextResponse.json({ error: "Token da Qase ausente." }, { status: 400 });
 
   const client = createQaseClient({ token, baseUrl, defaultFetchOptions: { cache: "no-store" } });
 
   try {
     // Qase supports GET /project/{code}
-    const path = `/project/${encodeURIComponent(projectCode)}`;
+    const path = `/project/${encodeURIComponent(request.projectCode)}`;
     const { data } = await client.getWithStatus<{ result?: unknown }>(path);
     // if success, consider valid
     return NextResponse.json({ valid: true, project: data.result ?? null }, { status: 200 });
   } catch (err) {
-    const statusCode = err instanceof QaseError ? err.status : 500;
-    if (statusCode === 404) return NextResponse.json({ valid: false, error: "Projeto não encontrado" }, { status: 404 });
-    if (statusCode === 401 || statusCode === 403) return NextResponse.json({ valid: false, error: "Token invalido ou sem acesso" }, { status: statusCode });
-    return NextResponse.json({ valid: false, error: "Erro ao validar projeto" }, { status: statusCode });
+    return validationErrorResponse(err);
   }
 }

--- a/app/api/auth/reset-request/route.ts
+++ b/app/api/auth/reset-request/route.ts
@@ -9,49 +9,68 @@ import {
   resolveReviewQueue,
 } from "@/lib/requestRouting";
 
-export async function POST(req: Request) {
-  const body = await req.json().catch(() => null);
-  const login = typeof body?.user === "string" ? body.user.trim().toLowerCase() : "";
-  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
-  const rawProfileType = typeof body?.profile_type === "string" ? body.profile_type : "";
+type ResetRequestBody = {
+  login: string;
+  email: string;
+  rawProfileType: string;
+};
 
+type ResetUser = NonNullable<Awaited<ReturnType<typeof findLocalUserByEmailOrId>>>;
+type LocalCompany = Awaited<ReturnType<typeof listLocalCompanies>>[number];
+
+async function parseResetRequestBody(req: Request): Promise<ResetRequestBody> {
+  const body = await req.json().catch(() => null);
+  return {
+    login: typeof body?.user === "string" ? body.user.trim().toLowerCase() : "",
+    email: typeof body?.email === "string" ? body.email.trim().toLowerCase() : "",
+    rawProfileType: typeof body?.profile_type === "string" ? body.profile_type : "",
+  };
+}
+
+async function validateResetUser(login: string, email: string) {
   if (!login || !email) {
     return NextResponse.json({ error: "Usuário e email obrigatorios" }, { status: 400 });
   }
 
   const user = await findLocalUserByEmailOrId(login);
-  if (!user) {
+  if (!user || (user.email ?? "").toLowerCase() !== email) {
     return NextResponse.json({ error: "Usuário e email não conferem" }, { status: 400 });
   }
-  if ((user.email ?? "").toLowerCase() !== email) {
-    return NextResponse.json({ error: "Usuário e email não conferem" }, { status: 400 });
-  }
+  return user;
+}
 
-  const profileType =
-    normalizeRequestProfileType(rawProfileType) ??
-    deriveProfileTypeFromAccount({
-      role: user.role,
-      globalRole: user.globalRole ?? null,
-      isGlobalAdmin: user.is_global_admin === true,
-    });
-  const reviewQueue = resolveReviewQueue(profileType);
-
+async function resolvePreferredCompany(user: ResetUser): Promise<LocalCompany | null> {
   const [links, companies] = await Promise.all([
     listLocalLinksForUser(user.id),
     listLocalCompanies(),
   ]);
   const companyById = new Map(companies.map((company) => [company.id, company]));
-  const preferredCompany =
+  return (
     (user.default_company_slug
       ? companies.find((company) => company.slug === user.default_company_slug)
       : null) ??
-    (links.length > 0 ? companyById.get(links[0].companyId) ?? null : null);
+    (links.length > 0 ? companyById.get(links[0].companyId) ?? null : null)
+  );
+}
 
-  let requestRecord = null;
-  const preferredCompanyName =
-    preferredCompany?.name ?? preferredCompany?.company_name ?? undefined;
+function resolveProfileType(user: ResetUser, rawProfileType: string) {
+  return (
+    normalizeRequestProfileType(rawProfileType) ??
+    deriveProfileTypeFromAccount({
+      role: user.role,
+      globalRole: user.globalRole ?? null,
+      isGlobalAdmin: user.is_global_admin === true,
+    })
+  );
+}
+
+async function createPasswordResetRequest(user: ResetUser, login: string, rawProfileType: string, preferredCompany: LocalCompany | null) {
+  const profileType = resolveProfileType(user, rawProfileType);
+  const reviewQueue = resolveReviewQueue(profileType);
+  const preferredCompanyName = preferredCompany?.name ?? preferredCompany?.company_name ?? undefined;
+
   try {
-    requestRecord = await addRequest(
+    return await addRequest(
       {
         id: user.id,
         name: user.full_name?.trim() || user.name,
@@ -70,8 +89,25 @@ export async function POST(req: Request) {
   } catch (err) {
     const code = err && typeof err === "object" ? (err as { code?: string }).code : null;
     if (code !== "DUPLICATE") {
-      return NextResponse.json({ error: "Erro ao registrar solicitação" }, { status: 500 });
+      throw err;
     }
+    return null;
+  }
+}
+
+export async function POST(req: Request) {
+  const { login, email, rawProfileType } = await parseResetRequestBody(req);
+  const userOrResponse = await validateResetUser(login, email);
+  if (userOrResponse instanceof NextResponse) return userOrResponse;
+
+  const user = userOrResponse;
+  const preferredCompany = await resolvePreferredCompany(user);
+  const preferredCompanyName = preferredCompany?.name ?? preferredCompany?.company_name ?? undefined;
+  let requestRecord = null;
+  try {
+    requestRecord = await createPasswordResetRequest(user, login, rawProfileType, preferredCompany);
+  } catch {
+    return NextResponse.json({ error: "Erro ao registrar solicitação" }, { status: 500 });
   }
 
   if (requestRecord) {

--- a/app/api/brain/graph/ingest/route.ts
+++ b/app/api/brain/graph/ingest/route.ts
@@ -50,6 +50,106 @@ function normalizeMemoryType(value: unknown) {
   return null;
 }
 
+function validateEventType(eventType: string) {
+  if (!eventType) {
+    return NextResponse.json({ error: "eventType e obrigatorio" }, { status: 400 });
+  }
+
+  if (!isAllowedBrainEvent(eventType) && !eventType.startsWith("custom.")) {
+    return NextResponse.json({
+      error: "eventType fora do contrato de ingestao do Brain",
+      hint: "Use eventos registrados em BrainModuleEvents ou prefixo custom.*",
+    }, { status: 400 });
+  }
+
+  return null;
+}
+
+async function ingestNode(body: IngestPayload, eventType: string, userId: string) {
+  if (!body.node?.type || !body.node?.label) return null;
+
+  const metadata = {
+    ...toRecord(body.node.metadata),
+    ...(body.companySlug ? { companySlug: body.companySlug } : {}),
+    source: body.source ?? eventType,
+    createdBy: userId,
+  };
+
+  return upsertNode({
+    type: body.node.type,
+    label: body.node.label,
+    refType: body.node.refType,
+    refId: body.node.refId,
+    description: body.node.description,
+    metadata,
+    userId,
+    enforceOntology: true,
+  });
+}
+
+async function ingestEdge(body: IngestPayload, eventType: string, userId: string) {
+  if (!body.edge?.fromId || !body.edge?.toId || !body.edge?.type) return null;
+
+  const edgeMetadata = toRecord(body.edge.metadata);
+  return connectNodes(
+    body.edge.fromId,
+    body.edge.toId,
+    body.edge.type,
+    {
+      ...edgeMetadata,
+      reason: edgeMetadata.reason ?? `event:${eventType}`,
+      source: body.source ?? eventType,
+      createdBy: userId,
+      ...(body.companySlug ? { companySlug: body.companySlug } : {}),
+    },
+    userId,
+    { enforceOntology: true },
+  );
+}
+
+async function ingestMemory(body: IngestPayload, node: Awaited<ReturnType<typeof upsertNode>> | null, userId: string) {
+  const memoryType = normalizeMemoryType(body.memory?.memoryType);
+  if (!body.memory?.title || !body.memory?.summary || !memoryType) return null;
+
+  return addMemory({
+    title: body.memory.title,
+    summary: body.memory.summary,
+    memoryType,
+    importance: body.memory.importance ?? 1,
+    relatedNodeIds: body.memory.relatedNodeIds ?? (node ? [node.id] : []),
+    sourceType: body.memory.sourceType ?? "MANUAL",
+    sourceId: body.memory.sourceId,
+    userId,
+  });
+}
+
+async function writeIngestAudit(
+  body: IngestPayload,
+  eventType: string,
+  userId: string,
+  node: Awaited<ReturnType<typeof upsertNode>> | null,
+  edge: Awaited<ReturnType<typeof connectNodes>> | null,
+  memory: Awaited<ReturnType<typeof addMemory>> | null,
+) {
+  await prisma.brainAuditLog.create({
+    data: {
+      action: "INGEST_EVENT",
+      entityType: "BrainGraphEvent",
+      entityId: node?.id ?? edge?.id ?? memory?.id ?? eventType,
+      userId,
+      reason: `Ingest event: ${eventType}`,
+      after: {
+        eventType,
+        source: body.source ?? "api",
+        companySlug: body.companySlug ?? null,
+        hasNode: Boolean(node),
+        hasEdge: Boolean(edge),
+        hasMemory: Boolean(memory),
+      },
+    },
+  });
+}
+
 export async function POST(req: Request) {
   const accessResult = await resolveBrainAccess(req, { requireManage: true });
   if (!accessResult.ok) {
@@ -59,89 +159,15 @@ export async function POST(req: Request) {
   try {
     const body = (await req.json()) as IngestPayload;
     const eventType = (body.eventType ?? "custom.event").trim();
+    const eventError = validateEventType(eventType);
+    if (eventError) return eventError;
 
-    if (!eventType) {
-      return NextResponse.json({ error: "eventType e obrigatorio" }, { status: 400 });
-    }
+    const userId = accessResult.context.user.id;
+    const node = await ingestNode(body, eventType, userId);
+    const edge = await ingestEdge(body, eventType, userId);
+    const memory = await ingestMemory(body, node, userId);
 
-    if (!isAllowedBrainEvent(eventType) && !eventType.startsWith("custom.")) {
-      return NextResponse.json({
-        error: "eventType fora do contrato de ingestao do Brain",
-        hint: "Use eventos registrados em BrainModuleEvents ou prefixo custom.*",
-      }, { status: 400 });
-    }
-
-    let node = null;
-    if (body.node?.type && body.node?.label) {
-      const metadata = {
-        ...toRecord(body.node.metadata),
-        ...(body.companySlug ? { companySlug: body.companySlug } : {}),
-        source: body.source ?? eventType,
-        createdBy: accessResult.context.user.id,
-      };
-
-      node = await upsertNode({
-        type: body.node.type,
-        label: body.node.label,
-        refType: body.node.refType,
-        refId: body.node.refId,
-        description: body.node.description,
-        metadata,
-        userId: accessResult.context.user.id,
-        enforceOntology: true,
-      });
-    }
-
-    let edge = null;
-    if (body.edge?.fromId && body.edge?.toId && body.edge?.type) {
-      edge = await connectNodes(
-        body.edge.fromId,
-        body.edge.toId,
-        body.edge.type,
-        {
-          ...toRecord(body.edge.metadata),
-          reason: toRecord(body.edge.metadata).reason ?? `event:${eventType}`,
-          source: body.source ?? eventType,
-          createdBy: accessResult.context.user.id,
-          ...(body.companySlug ? { companySlug: body.companySlug } : {}),
-        },
-        accessResult.context.user.id,
-        { enforceOntology: true },
-      );
-    }
-
-    let memory = null;
-    const memoryType = normalizeMemoryType(body.memory?.memoryType);
-    if (body.memory?.title && body.memory?.summary && memoryType) {
-      memory = await addMemory({
-        title: body.memory.title,
-        summary: body.memory.summary,
-        memoryType,
-        importance: body.memory.importance ?? 1,
-        relatedNodeIds: body.memory.relatedNodeIds ?? (node ? [node.id] : []),
-        sourceType: body.memory.sourceType ?? "MANUAL",
-        sourceId: body.memory.sourceId,
-        userId: accessResult.context.user.id,
-      });
-    }
-
-    await prisma.brainAuditLog.create({
-      data: {
-        action: "INGEST_EVENT",
-        entityType: "BrainGraphEvent",
-        entityId: node?.id ?? edge?.id ?? memory?.id ?? eventType,
-        userId: accessResult.context.user.id,
-        reason: `Ingest event: ${eventType}`,
-        after: {
-          eventType,
-          source: body.source ?? "api",
-          companySlug: body.companySlug ?? null,
-          hasNode: Boolean(node),
-          hasEdge: Boolean(edge),
-          hasMemory: Boolean(memory),
-        },
-      },
-    });
+    await writeIngestAudit(body, eventType, userId, node, edge, memory);
 
     return NextResponse.json({
       eventType,

--- a/app/api/company-documents/route.ts
+++ b/app/api/company-documents/route.ts
@@ -67,7 +67,6 @@ function hasGlobalCompanyAccess(auth: Pick<AuthContext, "isGlobalAdmin" | "role"
 const STORE_PATH = path.join(getJsonStoreDir(), "company-documents-store.json");
 const HISTORY_PATH = path.join(getJsonStoreDir(), "company-documents-history.json");
 const LOCAL_UPLOAD_ROOT = path.join(getJsonStoreDir(), "company-documents-files");
-let memoryDocumentsStore: { items: CompanyDocumentItem[] } = { items: [] };
 let memoryHistoryStore: { items: DocumentHistoryEvent[] } = { items: [] };
 
 async function ensureStore() {
@@ -149,11 +148,11 @@ async function readStore(): Promise<{ items: CompanyDocumentItem[] }> {
   } catch {
     return { items: [] };
   }
-  return { items: (memoryDocumentsStore.items ?? []).map(normalizeDocumentItem) };
 }
 
 async function writeStore(next: { items: CompanyDocumentItem[] }) {
-  memoryDocumentsStore = { items: next.items ?? [] };
+  await ensureStore();
+  await fs.writeFile(STORE_PATH, JSON.stringify({ items: next.items ?? [] }, null, 2), "utf8");
 }
 
 async function readHistory(): Promise<{ items: DocumentHistoryEvent[] }> {

--- a/app/api/dashboard/summary/route.ts
+++ b/app/api/dashboard/summary/route.ts
@@ -12,7 +12,8 @@ export async function GET(req: Request, context: { params: Promise<{ slug?: stri
     const rate = await rateLimit(req, `dashboard-summary:${ip}`);
     if (rate.limited) return rate.response;
   const url = new URL(req.url);
-  const slug = url.searchParams.get("slug") || (context.params && (await context.params).slug) || null;
+  const params = await context.params;
+  const slug = url.searchParams.get("slug") || params.slug || null;
   if (!slug) {
     return NextResponse.json({ error: "Empresa não informada" }, { status: 400 });
   }

--- a/app/api/profile/companies/[companyId]/route.ts
+++ b/app/api/profile/companies/[companyId]/route.ts
@@ -34,7 +34,7 @@ export async function GET(
     }
 
     // Construir contexto (valida permissões)
-    const context = await buildProfileRuntimeContext({
+    const context = buildProfileRuntimeContext({
       viewer,
       entityType: "company",
       entityId: companyId,
@@ -117,7 +117,7 @@ export async function PATCH(
     }
 
     // Construir contexto (valida permissões)
-    const context = await buildProfileRuntimeContext({
+    const context = buildProfileRuntimeContext({
       viewer,
       entityType: "company",
       entityId: companyId,

--- a/app/api/profile/users/[userId]/route.ts
+++ b/app/api/profile/users/[userId]/route.ts
@@ -50,7 +50,7 @@ export async function GET(
     }
 
     // Construir contexto (valida permissões)
-    const context = await buildProfileRuntimeContext({
+    const context = buildProfileRuntimeContext({
       viewer,
       entityType: "user",
       entityId: userId,
@@ -127,7 +127,7 @@ export async function PATCH(
     }
 
     // Construir contexto (valida permissões)
-    const context = await buildProfileRuntimeContext({
+    const context = buildProfileRuntimeContext({
       viewer,
       entityType: "user",
       entityId: userId,

--- a/app/components/profile/ProfileActions.tsx
+++ b/app/components/profile/ProfileActions.tsx
@@ -4,7 +4,6 @@
  * Profile Actions — botões de ação contextuais
  */
 
-import { ReactNode } from "react";
 import { useProfileAction, useDangerZone, useProfileMode } from "@/lib/profile/useProfileContext";
 import { cn } from "@/lib/cn";
 
@@ -41,31 +40,40 @@ export function ProfileActions({
   const dangerZone = useDangerZone();
   const mode = useProfileMode();
   const canEdit = useProfileAction("edit");
+  const canDelete = useProfileAction("delete");
+  const canDeactivate = useProfileAction("deactivate");
+  const canArchive = useProfileAction("archive");
+  const canManageUsers = useProfileAction("manage_users");
+  const canManagePermissions = useProfileAction("manage_permissions");
+  const canManageLinks = useProfileAction("manage_links");
+  const canManageIntegrations = useProfileAction("manage_integrations");
+  const canViewAudit = useProfileAction("view_audit");
+  const canImpersonate = useProfileAction("impersonate");
+  const canBlock = useProfileAction("block");
+  const canResetPassword = useProfileAction("reset_password");
+  const canResendInvite = useProfileAction("resend_invite");
+
+  const actionPermissions: Record<Exclude<ProfileActionButton["action"], "custom">, boolean> = {
+    edit: canEdit,
+    save: mode === "edit" || mode === "admin-edit" || mode === "create",
+    cancel: mode === "edit" || mode === "admin-edit",
+    delete: dangerZone && canDelete,
+    deactivate: dangerZone && canDeactivate,
+    archive: dangerZone && canArchive,
+    manage_users: canManageUsers,
+    manage_permissions: canManagePermissions,
+    manage_links: canManageLinks,
+    manage_integrations: canManageIntegrations,
+    view_audit: canViewAudit,
+    impersonate: canImpersonate,
+    block: canBlock,
+    reset_password: canResetPassword,
+    resend_invite: canResendInvite,
+  };
 
   const visible = buttons.filter((btn) => {
     if (btn.action === "custom") return true;
-
-    // Verificar permissão
-    const actionMap = {
-      edit: () => canEdit,
-      save: () => mode === "edit" || mode === "admin-edit" || mode === "create",
-      cancel: () => mode === "edit" || mode === "admin-edit",
-      delete: () => dangerZone && useProfileAction("delete"),
-      deactivate: () => dangerZone && useProfileAction("deactivate"),
-      archive: () => dangerZone && useProfileAction("archive"),
-      manage_users: () => useProfileAction("manage_users"),
-      manage_permissions: () => useProfileAction("manage_permissions"),
-      manage_links: () => useProfileAction("manage_links"),
-      manage_integrations: () => useProfileAction("manage_integrations"),
-      view_audit: () => useProfileAction("view_audit"),
-      impersonate: () => useProfileAction("impersonate"),
-      block: () => useProfileAction("block"),
-      reset_password: () => useProfileAction("reset_password"),
-      resend_invite: () => useProfileAction("resend_invite"),
-    };
-
-    const checkFn = actionMap[btn.action as keyof typeof actionMap];
-    return checkFn ? checkFn() : true;
+    return actionPermissions[btn.action] ?? true;
   });
 
   return (

--- a/app/docs/DocsWikiClient.tsx
+++ b/app/docs/DocsWikiClient.tsx
@@ -1347,7 +1347,7 @@ export default function DocsWikiClient({ basePath = "/api/platform-docs" }: { ba
 
       {deleteTarget !== null && (
         <DeleteModal
-          title={deleteTarget.type === "category" ? `"${deleteTarget.item.title}"` : `"${deleteTarget.item.title}"`}
+          title={`"${deleteTarget.item.title}"`}
           warning={deleteTarget.type === "category" ? "Todos os documentos desta categoria também serão deletados." : undefined}
           onConfirm={deleteTarget.type === "category"
             ? () => handleDeleteCategory(deleteTarget.item.id)

--- a/app/empresas/[slug]/dashboard/CompanyIntelligenceDashboardClient.tsx
+++ b/app/empresas/[slug]/dashboard/CompanyIntelligenceDashboardClient.tsx
@@ -1897,10 +1897,14 @@ export default function CompanyIntelligenceDashboardClient(props: CompanyDashboa
     const applications = Array.from(appMap.values());
     const runs = enrichedRuns.map((run) => ({ key: run.slug, label: run.title }));
     const statuses = buildStatusOptions(enrichedRuns);
-    const environments = Array.from(new Set(enrichedRuns.flatMap((run) => run.environments))).sort();
+    const environments = Array.from(new Set(enrichedRuns.flatMap((run) => run.environments))).sort((left, right) =>
+      left.localeCompare(right, "pt-BR", { sensitivity: "base" }),
+    );
     const runResponsibles = enrichedRuns.flatMap((run) => parseCommaList(run.responsibleLabel));
     const memberNames = (props.companyMembers ?? []).map((m) => m.name);
-    const responsibles = Array.from(new Set([...runResponsibles, ...memberNames])).sort();
+    const responsibles = Array.from(new Set([...runResponsibles, ...memberNames])).sort((left, right) =>
+      left.localeCompare(right, "pt-BR", { sensitivity: "base" }),
+    );
     return { applications, runs, statuses, environments, responsibles };
   }, [enrichedRuns, props.companyMembers, props.applications]);
 
@@ -1945,14 +1949,14 @@ export default function CompanyIntelligenceDashboardClient(props: CompanyDashboa
           .filter((run) => matchesDraftRun(run, "environmentFilter"))
           .flatMap((run) => run.environments),
       ),
-    ).sort();
+    ).sort((left, right) => left.localeCompare(right, "pt-BR", { sensitivity: "base" }));
     const responsibles = Array.from(
       new Set(
         enrichedRuns
           .filter((run) => matchesDraftRun(run, "responsibleFilter"))
           .flatMap((run) => parseCommaList(run.responsibleLabel)),
       ),
-    ).sort();
+    ).sort((left, right) => left.localeCompare(right, "pt-BR", { sensitivity: "base" }));
 
     return { applications, runs, statuses, environments, responsibles };
   }, [

--- a/app/empresas/[slug]/defeitos/page.tsx
+++ b/app/empresas/[slug]/defeitos/page.tsx
@@ -1510,9 +1510,9 @@ export default function CompanyDefectsPage() {
       ) {
         return copy.timeline.notice;
       }
-      return locale === "pt-BR" ? message : message;
+      return message;
     },
-    [copy.timeline.notice, locale],
+    [copy.timeline.notice],
   );
 
   const localizeClientError = useCallback(
@@ -1927,12 +1927,7 @@ export default function CompanyDefectsPage() {
       const projectCode = normalizeProjectCode(projectValue) || null;
       const key = `${normalizeText(name)}:${normalizeProjectKey(projectCode)}`;
       const current = catalog.get(key);
-      const nextSource =
-        !current || current.source === source
-          ? source
-          : current.source === "mixed" || source === "mixed"
-            ? "mixed"
-            : "mixed";
+      const nextSource = !current || current.source === source ? source : "mixed";
 
       catalog.set(key, {
         name,

--- a/app/globals.css
+++ b/app/globals.css
@@ -5824,7 +5824,6 @@ video {
     flex: 0 0 0;
     width: 0;
     max-width: 0;
-    width: 0;
     min-width: 0;
     margin-left: 0 !important;
     margin-right: 0 !important;

--- a/app/login/LoginClient.module.css
+++ b/app/login/LoginClient.module.css
@@ -33,7 +33,7 @@
 }
 
 /* High zoom accessibility: ensure min width and readable font */
-@media (max-width: 400px), (max-zoom: 2.5) {
+@media (max-width: 400px) {
   .loginContainer {
     min-width: 0;
     font-size: 1.25rem;

--- a/app/login/LoginClient.tsx
+++ b/app/login/LoginClient.tsx
@@ -36,8 +36,8 @@ export default function LoginClient() {
   useEffect(() => {
     const html = document.documentElement;
     const body = document.body;
-    const previousRootAttr = html.getAttribute("data-login-route");
-    const previousBodyAttr = body.getAttribute("data-login-route");
+    const previousRootAttr = html.dataset.loginRoute;
+    const previousBodyAttr = body.dataset.loginRoute;
     const inlineTargets = [html, body];
     const inlineKeys = ["opacity", "filter", "backdrop-filter", "pointer-events"] as const;
     const previousInline = inlineTargets.map((target) => ({
@@ -49,8 +49,8 @@ export default function LoginClient() {
       })),
     }));
 
-    html.setAttribute("data-login-route", "true");
-    body.setAttribute("data-login-route", "true");
+    html.dataset.loginRoute = "true";
+    body.dataset.loginRoute = "true";
     for (const target of inlineTargets) {
       target.style.setProperty("opacity", "1", "important");
       target.style.setProperty("filter", "none", "important");
@@ -102,10 +102,10 @@ export default function LoginClient() {
     }
 
     return () => {
-      if (previousRootAttr === null) html.removeAttribute("data-login-route");
-      else html.setAttribute("data-login-route", previousRootAttr);
-      if (previousBodyAttr === null) body.removeAttribute("data-login-route");
-      else body.setAttribute("data-login-route", previousBodyAttr);
+      if (previousRootAttr === undefined) delete html.dataset.loginRoute;
+      else html.dataset.loginRoute = previousRootAttr;
+      if (previousBodyAttr === undefined) delete body.dataset.loginRoute;
+      else body.dataset.loginRoute = previousBodyAttr;
 
       for (const entry of previousInline) {
         for (const style of entry.styles) {

--- a/app/settings/profile/page.tsx
+++ b/app/settings/profile/page.tsx
@@ -814,7 +814,7 @@ export default function SettingsProfilePage() {
   const companyScopeKey = !loading && hasCompanyContext ? currentClientSlug ?? currentClientId ?? homeCompanyId : null;
   const uiRoleLabel = roleLabel(roleValue);
   const userStatusLabel = statusLabel(active, status, t);
-  const directDeleteModalTitle = isGlobalProfile ? t("settings.deleteProfile") : t("settings.deleteProfile");
+  const directDeleteModalTitle = t("settings.deleteProfile");
   const directDeleteModalDescription = t("settings.deleteProfileConfirm");
 
   const uniqueCompanies = useMemo(() => {

--- a/app/settings/profile/page.tsx
+++ b/app/settings/profile/page.tsx
@@ -298,9 +298,13 @@ function normalizeComparableText(value?: string | null) {
   return (value ?? "").trim();
 }
 
+function compareText(left: string, right: string) {
+  return left.localeCompare(right);
+}
+
 function areStringListsEqual(left: string[] | null | undefined, right: string[] | null | undefined) {
-  const normalizedLeft = (left ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort();
-  const normalizedRight = (right ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort();
+  const normalizedLeft = (left ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort(compareText);
+  const normalizedRight = (right ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort(compareText);
   if (normalizedLeft.length !== normalizedRight.length) return false;
   return normalizedLeft.every((value, index) => value === normalizedRight[index]);
 }

--- a/lib/accessRequestMessage.ts
+++ b/lib/accessRequestMessage.ts
@@ -269,12 +269,10 @@ export function extractAdminNotes(message: string): string | null {
   return notes || null;
 }
 
-export function composeAccessRequestMessage(input: ComposeAccessRequestInput): string {
-  const reviewQueue = resolveReviewQueue(input.profileType);
-  const companyProfile = normalizeCompanyProfile(input.companyProfile);
+function buildAccessRequestPayload(input: ComposeAccessRequestInput) {
   const snapshot = buildSnapshot(input);
   const originalRequest = normalizeSnapshot(input.originalRequest ?? snapshot);
-  const payload = {
+  return {
     v: 1,
     kind: "access_request",
     email: input.email,
@@ -288,12 +286,12 @@ export function composeAccessRequestMessage(input: ComposeAccessRequestInput): s
     clientId: input.clientId,
     accessType: input.accessType,
     profileType: input.profileType,
-    reviewQueue,
+    reviewQueue: resolveReviewQueue(input.profileType),
     mappedAppRole: input.accessType,
     title: input.title || null,
     description: input.description || null,
     notes: input.notes || null,
-    companyProfile,
+    companyProfile: normalizeCompanyProfile(input.companyProfile),
     originalRequest,
     adjustmentRound: typeof input.adjustmentRound === "number" ? input.adjustmentRound : 0,
     adjustmentRequestedFields: normalizeAdjustmentFields(input.adjustmentRequestedFields),
@@ -301,14 +299,20 @@ export function composeAccessRequestMessage(input: ComposeAccessRequestInput): s
     lastAdjustmentAt: input.lastAdjustmentAt ?? null,
     lastAdjustmentDiff: Array.isArray(input.lastAdjustmentDiff) ? input.lastAdjustmentDiff : [],
   };
+}
 
+function buildAccessRequestMessageLines(
+  input: ComposeAccessRequestInput,
+  payload: ReturnType<typeof buildAccessRequestPayload>,
+) {
+  const companyProfile = payload.companyProfile;
   const lines = [
     `ACCESS_REQUEST_V1 ${JSON.stringify(payload)}`,
     "Solicitacao de acesso registrada",
     input.title ? `Titulo da solicitacao: ${input.title}` : "",
     input.description ? `Descricao detalhada: ${input.description}` : "",
     `Tipo de perfil: ${toRequestProfileTypeLabel(input.profileType)}`,
-    `Destino da fila: ${reviewQueue === "global_only" ? "Global" : "Admin e Global"}`,
+    `Destino da fila: ${payload.reviewQueue === "global_only" ? "Global" : "Admin e Global"}`,
     `Tipo de acesso interno: ${toAccessTypeLabel(input.accessType)}`,
     `Empresa: ${input.company}${input.clientId ? ` (id: ${input.clientId})` : ""}`,
     companyProfile?.companyName ? `Empresa solicitada: ${companyProfile.companyName}` : "",
@@ -327,6 +331,12 @@ export function composeAccessRequestMessage(input: ComposeAccessRequestInput): s
     `Email: ${input.email}`,
     input.notes ? `Observacoes: ${input.notes}` : "",
   ].filter(Boolean);
+  return lines;
+}
+
+export function composeAccessRequestMessage(input: ComposeAccessRequestInput): string {
+  const payload = buildAccessRequestPayload(input);
+  const lines = buildAccessRequestMessageLines(input, payload);
 
   if (input.adminNotes && input.adminNotes.trim()) {
     lines.push(`ADMIN_NOTES: ${input.adminNotes.trim()}`);

--- a/lib/auth/sessionBuilder.ts
+++ b/lib/auth/sessionBuilder.ts
@@ -6,9 +6,7 @@ import {
   listLocalLinksForUser,
   normalizeLocalRole,
 } from "@/lib/auth/localStore";
-import { resolvePermissionRoleForUser } from "@/lib/adminUsers";
 import { resolveCapabilities } from "@/lib/permissions";
-import { resolveVisibleCompanies, resolveCompanyVisibilityMode } from "@/lib/companyVisibility";
 
 export type BuiltSessionPayload = {
   userId: string;
@@ -45,6 +43,77 @@ export type BuiltSession = {
   requestedCompanySlug: string | null;
 };
 
+type LocalSessionUser = NonNullable<Awaited<ReturnType<typeof getLocalUserById>>>;
+type LocalCompany = Awaited<ReturnType<typeof listLocalCompanies>>[number];
+type LocalCompanyLink = Awaited<ReturnType<typeof listLocalLinksForUser>>[number];
+
+function userHasRole(
+  user: LocalSessionUser,
+  links: LocalCompanyLink[],
+  expectedRole: string,
+) {
+  return (
+    normalizeLocalRole(user.role ?? null) === expectedRole ||
+    links.some((link) => normalizeLocalRole(link.role ?? null) === expectedRole)
+  );
+}
+
+function hasDirectCompanyRole(user: LocalSessionUser) {
+  const role = normalizeLocalRole(user.role ?? null);
+  return role === "empresa" || role === "company_user" || user.user_origin === "client_company";
+}
+
+function canAccessCompanyDirectly(user: LocalSessionUser, company: LocalCompany) {
+  return Boolean(user.default_company_slug && company.slug === user.default_company_slug);
+}
+
+function resolveAllowedSessionCompanies(input: {
+  companies: LocalCompany[];
+  hasFullCompanyAccess: boolean;
+  isDirectCompanyUser: boolean;
+  links: LocalCompanyLink[];
+  user: LocalSessionUser;
+}) {
+  if (input.hasFullCompanyAccess) return input.companies;
+
+  return input.companies.filter((company) => {
+    if (input.links.some((link) => link.companyId === company.id)) return true;
+    return input.isDirectCompanyUser && canAccessCompanyDirectly(input.user, company);
+  });
+}
+
+function resolveRequestedCompany(
+  allowedCompanies: LocalCompany[],
+  requestedSlug: string,
+  shouldBindCompanyContext: boolean,
+) {
+  if (!shouldBindCompanyContext || !requestedSlug || allowedCompanies.length === 0) return null;
+  return allowedCompanies.find((company) => company.slug === requestedSlug) ?? null;
+}
+
+function resolveActiveCompany(input: {
+  allowedCompanies: LocalCompany[];
+  requestedCompany: LocalCompany | null;
+  shouldBindCompanyContext: boolean;
+  user: LocalSessionUser;
+}) {
+  if (!input.shouldBindCompanyContext) return null;
+  return (
+    input.requestedCompany ??
+    input.allowedCompanies.find((company) => company.slug === input.user.default_company_slug) ??
+    input.allowedCompanies[0] ??
+    null
+  );
+}
+
+function resolveDisplayName(user: LocalSessionUser) {
+  return (
+    (typeof user.full_name === "string" ? user.full_name.trim() : "") ||
+    (typeof user.name === "string" ? user.name.trim() : "") ||
+    user.email
+  );
+}
+
 export async function buildLocalSessionForUser(
   userId: string,
   opts?: { requestedSlug?: string | null },
@@ -58,36 +127,30 @@ export async function buildLocalSessionForUser(
   ]);
 
   const isGlobalAdmin = user.globalRole === "global_admin" || user.is_global_admin === true;
-  const hasTechnicalSupportRole =
-    normalizeLocalRole(user.role ?? null) === "technical_support" ||
-    links.some((link) => normalizeLocalRole(link.role ?? null) === "technical_support");
-  const hasLeaderTcRole =
-    normalizeLocalRole(user.role ?? null) === "leader_tc" ||
-    links.some((link) => normalizeLocalRole(link.role ?? null) === "leader_tc");
+  const hasTechnicalSupportRole = userHasRole(user, links, "technical_support");
+  const hasLeaderTcRole = userHasRole(user, links, "leader_tc");
   const hasFullCompanyAccess = isGlobalAdmin || hasTechnicalSupportRole || hasLeaderTcRole;
   const shouldBindCompanyContext = !hasFullCompanyAccess;
-  const isDirectCompanyUser = normalizeLocalRole(user.role ?? null) === "empresa" || normalizeLocalRole(user.role ?? null) === "company_user" || user.user_origin === "client_company";
-  const allowedCompanies = hasFullCompanyAccess
-    ? companies
-    : companies.filter((company) => {
-        if (links.some((link) => link.companyId === company.id)) return true;
-        if (!isDirectCompanyUser) return false;
-        return Boolean(user.default_company_slug && company.slug === user.default_company_slug);
-      });
+  const allowedCompanies = resolveAllowedSessionCompanies({
+    companies,
+    hasFullCompanyAccess,
+    isDirectCompanyUser: hasDirectCompanyRole(user),
+    links,
+    user,
+  });
 
   const requestedSlug = typeof opts?.requestedSlug === "string" ? opts.requestedSlug.trim() : "";
-  const requestedCompany =
-    shouldBindCompanyContext && requestedSlug && allowedCompanies.length
-      ? allowedCompanies.find((company) => company.slug === requestedSlug) ?? null
-      : null;
-
-  const activeCompany =
-    shouldBindCompanyContext
-      ? requestedCompany ??
-        allowedCompanies.find((company) => company.slug === user.default_company_slug) ??
-        allowedCompanies[0] ??
-        null
-      : null;
+  const requestedCompany = resolveRequestedCompany(
+    allowedCompanies,
+    requestedSlug,
+    shouldBindCompanyContext,
+  );
+  const activeCompany = resolveActiveCompany({
+    allowedCompanies,
+    requestedCompany,
+    shouldBindCompanyContext,
+    user,
+  });
 
   const activeLink = activeCompany ? links.find((link) => link.companyId === activeCompany.id) ?? null : null;
   const companyRole = normalizeLocalRole(activeLink?.role ?? user.role ?? null);
@@ -100,15 +163,10 @@ export async function buildLocalSessionForUser(
 
   const effectiveRole = isGlobalAdmin ? "leader_tc" : companyRole;
 
-  const displayName =
-    (typeof user.full_name === "string" ? user.full_name.trim() : "") ||
-    (typeof user.name === "string" ? user.name.trim() : "") ||
-    user.email;
-
   const session: BuiltSessionPayload = {
     userId: user.id,
     email: user.email,
-    name: displayName,
+    name: resolveDisplayName(user),
     companyId: shouldBindCompanyContext ? activeCompany?.id ?? null : null,
     companySlug: shouldBindCompanyContext ? activeCompany?.slug ?? null : null,
     defaultCompanySlug: user.default_company_slug ?? null,

--- a/lib/automationPrismaClient.ts
+++ b/lib/automationPrismaClient.ts
@@ -45,7 +45,7 @@ function recreateAutomationPrismaClient() {
   return client;
 }
 
-export let automationPrisma: PrismaClient =
+let currentAutomationPrisma: PrismaClient =
   globalForAutomationPrisma.automationPrisma ??
   (hasDatabaseUrl()
     ? createAutomationPrismaClient()
@@ -53,11 +53,25 @@ export let automationPrisma: PrismaClient =
       ? createUnavailablePrismaClient()
       : createAutomationPrismaClient());
 
+function createAutomationPrismaClientProxy(): PrismaClient {
+  return new Proxy({} as PrismaClient, {
+    get(_target, prop) {
+      const value = Reflect.get(currentAutomationPrisma as object, prop, currentAutomationPrisma);
+      return typeof value === "function" ? value.bind(currentAutomationPrisma) : value;
+    },
+    set(_target, prop, value) {
+      return Reflect.set(currentAutomationPrisma as object, prop, value, currentAutomationPrisma);
+    },
+  });
+}
+
+export const automationPrisma: PrismaClient = createAutomationPrismaClientProxy();
+
 if (process.env.NODE_ENV !== "production") {
-  globalForAutomationPrisma.automationPrisma = automationPrisma;
+  globalForAutomationPrisma.automationPrisma = currentAutomationPrisma;
 }
 
 export function reconnectAutomationPrisma() {
   console.info("[automation-prisma] Reconnecting after connection loss...");
-  automationPrisma = recreateAutomationPrismaClient();
+  currentAutomationPrisma = recreateAutomationPrismaClient();
 }

--- a/lib/brain.ts
+++ b/lib/brain.ts
@@ -706,8 +706,6 @@ export async function getRelatedMemories(
       const ids = Array.isArray(m.relatedNodeIds) ? m.relatedNodeIds : [];
       return (ids as unknown[]).some((id) => allNodeIds.includes(String(id)));
     })
-
-    return memories
   } catch (error) {
     console.error('Error in getRelatedMemories:', error)
     throw error

--- a/lib/brain/contextual/contextBuilder.ts
+++ b/lib/brain/contextual/contextBuilder.ts
@@ -21,10 +21,10 @@ export function buildBrianContextSummary(result: BrianProcessingResult) {
     "",
     topNeurons.length ? "Neurônios ativados:" : "",
     ...topNeurons,
-    evidenceLines.length ? "" : "",
+    "",
     evidenceLines.length ? "Evidências:" : "",
     ...evidenceLines,
-    result.warnings.length ? "" : "",
+    "",
     result.warnings.length ? "Avisos:" : "",
     ...result.warnings.map((warning) => `- ${warning}`),
   ].filter((line) => line !== "").join("\n");

--- a/lib/companyRecord.ts
+++ b/lib/companyRecord.ts
@@ -75,9 +75,13 @@ export function normalizeTaxId(value: string | null | undefined) {
   return (value ?? "").replace(/\D+/g, "");
 }
 
+function compareText(left: string, right: string) {
+  return left.localeCompare(right);
+}
+
 export function areProjectCodesEqual(left: string[] | null, right: string[] | null) {
-  const normalizedLeft = (left ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort();
-  const normalizedRight = (right ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort();
+  const normalizedLeft = (left ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort(compareText);
+  const normalizedRight = (right ?? []).map((item) => item.trim().toUpperCase()).filter(Boolean).sort(compareText);
   if (normalizedLeft.length !== normalizedRight.length) return false;
   return normalizedLeft.every((value, index) => value === normalizedRight[index]);
 }

--- a/lib/companyRoutes.ts
+++ b/lib/companyRoutes.ts
@@ -17,32 +17,21 @@ export function resolveCompanyRouteAccessInput(input: {
   user?: Record<string, unknown> | null;
 }): CompanyRouteAccessInput {
   const user = (input?.user ?? {}) as Record<string, unknown>;
-
-  const clientSlug =
-    normalizeSlug(typeof user.clientSlug === "string" ? user.clientSlug : null)?.toLowerCase() ??
-    normalizeSlug(typeof user.client_slug === "string" ? user.client_slug : null)?.toLowerCase() ??
-    normalizeSlug(typeof user.companySlug === "string" ? user.companySlug : null)?.toLowerCase() ??
-    normalizeSlug(typeof user.company_slug === "string" ? user.company_slug : null)?.toLowerCase();
-
-  const defaultClientSlug =
-    normalizeSlug(typeof user.defaultClientSlug === "string" ? user.defaultClientSlug : null)?.toLowerCase() ??
-    normalizeSlug(typeof user.default_client_slug === "string" ? user.default_client_slug : null)?.toLowerCase() ??
-    null;
-
-  const companyCount =
-    typeof user.companyCount === "number"
-      ? user.companyCount
-      : clientSlug
-        ? 1
-        : 0;
+  const clientSlug = readLowerSlug(user, [
+    "clientSlug",
+    "client_slug",
+    "companySlug",
+    "company_slug",
+  ]);
+  const defaultClientSlug = readLowerSlug(user, ["defaultClientSlug", "default_client_slug"]);
 
   return {
     isGlobalAdmin: typeof user.isGlobalAdmin === "boolean" ? user.isGlobalAdmin : null,
-    permissionRole: typeof user.permissionRole === "string" ? user.permissionRole : null,
-    role: typeof user.role === "string" ? user.role : null,
-    companyRole: typeof user.companyRole === "string" ? user.companyRole : null,
-    userOrigin: typeof user.user_origin === "string" ? user.user_origin : typeof user.userOrigin === "string" ? user.userOrigin : null,
-    companyCount,
+    permissionRole: readString(user, "permissionRole"),
+    role: readString(user, "role"),
+    companyRole: readString(user, "companyRole"),
+    userOrigin: readString(user, "user_origin") ?? readString(user, "userOrigin"),
+    companyCount: resolveCompanyCount(user, clientSlug),
     clientSlug,
     defaultClientSlug,
     isInstitutionalCompany: typeof user.isInstitutionalCompany === "boolean" ? user.isInstitutionalCompany : undefined,
@@ -147,6 +136,23 @@ function normalizeSlug(value?: string | null) {
   return normalized || null;
 }
 
+function readString(record: Record<string, unknown>, key: string) {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readLowerSlug(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const normalized = normalizeSlug(readString(record, key));
+    if (normalized) return normalized.toLowerCase();
+  }
+  return null;
+}
+
+function resolveCompanyCount(record: Record<string, unknown>, clientSlug?: string | null) {
+  return typeof record.companyCount === "number" ? record.companyCount : clientSlug ? 1 : 0;
+}
+
 function normalizeRoute(route?: string | null) {
   const value = (route ?? "").trim();
   if (!value) return "home";
@@ -163,41 +169,52 @@ function buildPathFromSegments(segments: string[], route?: string | null) {
   return encodePathSegments([...segments, ...routeSegments]);
 }
 
+function resolveLegacyRouteRoles(input: CompanyRouteAccessInput) {
+  return {
+    permissionRole: normalizeLegacyRole(input.permissionRole ?? null),
+    role: normalizeLegacyRole(input.role ?? null),
+    companyRole: normalizeLegacyRole(input.companyRole ?? null),
+  };
+}
+
+function hasLegacyRouteRole(
+  roles: ReturnType<typeof resolveLegacyRouteRoles>,
+  expectedRole: FixedProfileKind,
+) {
+  return Object.values(roles).includes(expectedRole);
+}
+
 function resolveProfileKind(input?: CompanyRouteAccessInput | null): FixedProfileKind | null {
   if (!input) return null;
 
-  const permissionRole = normalizeLegacyRole(input.permissionRole ?? null);
-  const role = normalizeLegacyRole(input.role ?? null);
-  const companyRole = normalizeLegacyRole(input.companyRole ?? null);
+  const roles = resolveLegacyRouteRoles(input);
   const origin = normalizeValue(input.userOrigin);
 
   // Internal profiles from testing_company always use long /empresas/ routes
   if (origin === "testing_company") return null;
 
-  if (input.isGlobalAdmin === true || permissionRole === SYSTEM_ROLES.LEADER_TC || role === SYSTEM_ROLES.LEADER_TC || companyRole === SYSTEM_ROLES.LEADER_TC) {
+  if (input.isGlobalAdmin === true || hasLegacyRouteRole(roles, SYSTEM_ROLES.LEADER_TC)) {
     return SYSTEM_ROLES.LEADER_TC;
   }
 
   // companyRole reflects the user's role for the active company in their session.
   // It must take priority over permissionRole (which is system-wide and can include
   // cross-company TS links) to avoid routing empresa accounts through /suporte/.
-  if (input.isInstitutionalCompany === true || companyRole === SYSTEM_ROLES.EMPRESA) {
+  if (input.isInstitutionalCompany === true || roles.companyRole === SYSTEM_ROLES.EMPRESA) {
     return SYSTEM_ROLES.EMPRESA;
   }
 
-  if (permissionRole === SYSTEM_ROLES.TECHNICAL_SUPPORT || role === SYSTEM_ROLES.TECHNICAL_SUPPORT || companyRole === SYSTEM_ROLES.TECHNICAL_SUPPORT) {
+  if (hasLegacyRouteRole(roles, SYSTEM_ROLES.TECHNICAL_SUPPORT)) {
     return SYSTEM_ROLES.TECHNICAL_SUPPORT;
   }
 
-  if (permissionRole === SYSTEM_ROLES.EMPRESA || role === SYSTEM_ROLES.EMPRESA) {
+  if (roles.permissionRole === SYSTEM_ROLES.EMPRESA || roles.role === SYSTEM_ROLES.EMPRESA) {
     return SYSTEM_ROLES.EMPRESA;
   }
 
   if (
     origin === "client_company" ||
-    permissionRole === SYSTEM_ROLES.COMPANY_USER ||
-    role === SYSTEM_ROLES.COMPANY_USER ||
-    companyRole === SYSTEM_ROLES.COMPANY_USER
+    hasLegacyRouteRole(roles, SYSTEM_ROLES.COMPANY_USER)
   ) {
     return SYSTEM_ROLES.COMPANY_USER;
   }

--- a/lib/core/auth/RequireClient.tsx
+++ b/lib/core/auth/RequireClient.tsx
@@ -5,13 +5,76 @@ import { ReactNode, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { AuthSkeleton } from "@/components/AuthSkeleton";
 import { useAuthUser } from "@/hooks/useAuthUser";
-import { buildCompanyPath, buildCompanyPathForAccess } from "@/lib/companyRoutes";
+import { buildCompanyPath } from "@/lib/companyRoutes";
 
 type RequireClientProps = {
   slug?: string; // slug da rota /empresas/[slug]
   children: ReactNode;
   fallback?: ReactNode;
 };
+
+type RequireClientAccessState =
+  | "allowed"
+  | "denied"
+  | "error"
+  | "expired"
+  | "loading"
+  | "slug-missing"
+  | "timeout";
+
+function readUserString(user: unknown, key: string) {
+  const value = (user as Record<string, unknown> | null | undefined)?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function normalizeRole(user: unknown, key: string) {
+  return readUserString(user, key)?.toLowerCase() ?? null;
+}
+
+function resolveRoleAccess(user: unknown, slug?: string) {
+  const role = normalizeRole(user, "role");
+  const permissionRole = normalizeRole(user, "permissionRole");
+  const isAdmin =
+    role === "leader_tc" ||
+    role === "technical_support" ||
+    permissionRole === "leader_tc" ||
+    permissionRole === "technical_support" ||
+    (user as { isGlobalAdmin?: boolean } | null | undefined)?.isGlobalAdmin === true;
+  const isTcUser = role === "testing_company_user" || permissionRole === "testing_company_user";
+  const linkedSlugs = (user as { clientSlugs?: unknown } | null | undefined)?.clientSlugs;
+  const isLinkedTcUser =
+    isTcUser &&
+    !!slug &&
+    Array.isArray(linkedSlugs) &&
+    linkedSlugs.some((value) => typeof value === "string" && value.toLowerCase() === slug.toLowerCase());
+  return { isAdmin, isLinkedTcUser };
+}
+
+function resolveNormalizedClientSlug(user: unknown) {
+  return readUserString(user, "clientSlug") ?? readUserString(user, "companySlug");
+}
+
+function resolveRequireClientAccessState(input: {
+  error: unknown;
+  isAdmin: boolean;
+  isLinkedTcUser: boolean;
+  loading: boolean;
+  normalizedClientSlug: string | null;
+  slug?: string;
+  timedOut: boolean;
+  user: unknown;
+}): RequireClientAccessState {
+  if (input.error) return "error";
+  if (input.loading && input.timedOut) return "timeout";
+  if (input.loading) return "loading";
+  if (!input.user) return "expired";
+  if (!input.slug) return "slug-missing";
+  if (input.isAdmin || input.isLinkedTcUser) return "allowed";
+  if (!input.normalizedClientSlug) return "denied";
+  return input.normalizedClientSlug.toLowerCase() === input.slug.toLowerCase()
+    ? "allowed"
+    : "denied";
+}
 
 export function RequireClient({ slug, children, fallback }: RequireClientProps) {
   const { user, loading, error, refreshUser } = useAuthUser();
@@ -34,39 +97,31 @@ export function RequireClient({ slug, children, fallback }: RequireClientProps) 
     return () => clearTimeout(handle);
   }, [loading]);
 
-  const role = typeof user?.role === "string" ? user.role.toLowerCase() : null;
-  const permissionRole = typeof user?.permissionRole === "string" ? user.permissionRole.toLowerCase() : null;
-  const isAdmin = role === "leader_tc" || role === "technical_support" || permissionRole === "leader_tc" || permissionRole === "technical_support" || user?.isGlobalAdmin === true;
-  // testing_company_user can be linked to multiple companies; allow access to any of their clientSlugs
-  const isTcUser = role === "testing_company_user" || permissionRole === "testing_company_user";
-  const linkedSlugs: string[] = Array.isArray(user?.clientSlugs) ? (user.clientSlugs as string[]) : [];
-  const isLinkedTcUser = isTcUser && !!slug && linkedSlugs.some((s) => s.toLowerCase() === slug.toLowerCase());
+  const { isAdmin, isLinkedTcUser } = resolveRoleAccess(user, slug);
   const loginHref =
     pathname.startsWith("/") && pathname !== "/login" ? `/login?next=${encodeURIComponent(pathname)}` : "/login";
 
-  const normalizedClientSlug = typeof user?.clientSlug === "string" ? user.clientSlug : typeof (user as { companySlug?: string | null } | null)?.companySlug === "string" ? (user as { companySlug?: string | null }).companySlug : null;
+  const normalizedClientSlug = resolveNormalizedClientSlug(user);
 
   const accessState = useMemo(() => {
-    if (error) return "error" as const;
-    if (loading && timedOut) return "timeout" as const;
-    if (loading) return "loading" as const;
-    if (!user) return "expired" as const;
-    if (!slug) return "slug-missing" as const;
-    if (isAdmin || isLinkedTcUser) return "allowed" as const;
-    if (!normalizedClientSlug) return "denied" as const;
-    if (slug && normalizedClientSlug.toLowerCase() !== slug.toLowerCase()) return "denied" as const;
-    return "allowed" as const;
+    return resolveRequireClientAccessState({
+      error,
+      isAdmin,
+      isLinkedTcUser,
+      loading,
+      normalizedClientSlug,
+      slug,
+      timedOut,
+      user,
+    });
   }, [error, isAdmin, isLinkedTcUser, loading, normalizedClientSlug, slug, timedOut, user]);
 
   useEffect(() => {
     if (loading) return;
     if (!user) {
       router.replace(loginHref);
-      return;
     }
-    void isAdmin;
-    void isLinkedTcUser;
-  }, [isAdmin, loading, loginHref, router, slug, user]);
+  }, [loading, loginHref, router, user]);
 
   if (!mounted || accessState === "loading") {
     return (fallback as ReactNode) ?? <AuthSkeleton message="Validando acesso da empresa" />;

--- a/lib/core/auth/pgStore.ts
+++ b/lib/core/auth/pgStore.ts
@@ -495,7 +495,6 @@ export async function pgCreateLocalCompany(
   // re-fetch with integrations
   const full = await prisma.company.findUnique({ where: { id: company.id }, include: { integrations: true } });
   return toLocalCompany(full as PrismaCompany);
-  return toLocalCompany(company);
 }
 
 export async function pgUpdateLocalCompany(
@@ -517,7 +516,7 @@ export async function pgUpdateLocalCompany(
           : []
         : undefined;
 
-  const company = await prisma.company.update({
+  await prisma.company.update({
     where: { id },
     data: {
       ...(patch.name
@@ -582,7 +581,6 @@ export async function pgUpdateLocalCompany(
   }
   const full = await prisma.company.findUnique({ where: { id }, include: { integrations: true } });
   return full ? toLocalCompany(full as PrismaCompany) : null;
-  return toLocalCompany(company);
 }
 
 export async function pgDeleteLocalCompany(id: string): Promise<boolean> {

--- a/lib/core/company/CompanyContext.tsx
+++ b/lib/core/company/CompanyContext.tsx
@@ -238,8 +238,8 @@ export function ClientProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const root = document.documentElement;
     const slug = (activeClientSlug ?? "").trim().toLowerCase();
-    if (slug) root.setAttribute("data-client", slug);
-    else root.removeAttribute("data-client");
+    if (slug) root.dataset.client = slug;
+    else delete root.dataset.client;
 
     const theme = slug ? CLIENT_THEME_MAP[slug] : undefined;
     root.style.setProperty("--tc-accent", theme?.accent ?? DEFAULT_THEME.accent);

--- a/lib/core/company/CompanyContext.tsx
+++ b/lib/core/company/CompanyContext.tsx
@@ -21,6 +21,25 @@ type ClientTheme = {
 
 const CLIENT_THEME_MAP_RAW = process.env.NEXT_PUBLIC_CLIENT_THEME_MAP || "";
 
+function normalizeClientThemeEntry(key: string, value: unknown): [string, ClientTheme] | null {
+  if (!key || !value || typeof value !== "object") return null;
+
+  const slug = key.trim().toLowerCase();
+  if (!slug) return null;
+
+  const record = value as Record<string, unknown>;
+  return [
+    slug,
+    {
+      accent: typeof record.accent === "string" ? record.accent : undefined,
+      accentHover: typeof record.accentHover === "string" ? record.accentHover : undefined,
+      accentActive: typeof record.accentActive === "string" ? record.accentActive : undefined,
+      accentSoft: typeof record.accentSoft === "string" ? record.accentSoft : undefined,
+      watermarkOpacity: typeof record.watermarkOpacity === "number" ? record.watermarkOpacity : undefined,
+    },
+  ];
+}
+
 function parseClientThemeMap(raw: string): Record<string, ClientTheme> {
   const trimmed = raw.trim();
   if (!trimmed) return {};
@@ -30,18 +49,8 @@ function parseClientThemeMap(raw: string): Record<string, ClientTheme> {
     const rec = parsed as Record<string, unknown>;
     const out: Record<string, ClientTheme> = {};
     for (const [k, v] of Object.entries(rec)) {
-      if (!k) continue;
-      if (!v || typeof v !== "object") continue;
-      const slug = k.trim().toLowerCase();
-      if (!slug) continue;
-      const vv = v as Record<string, unknown>;
-      out[slug] = {
-        accent: typeof vv.accent === "string" ? vv.accent : undefined,
-        accentHover: typeof vv.accentHover === "string" ? vv.accentHover : undefined,
-        accentActive: typeof vv.accentActive === "string" ? vv.accentActive : undefined,
-        accentSoft: typeof vv.accentSoft === "string" ? vv.accentSoft : undefined,
-        watermarkOpacity: typeof vv.watermarkOpacity === "number" ? vv.watermarkOpacity : undefined,
-      };
+      const entry = normalizeClientThemeEntry(k, v);
+      if (entry) out[entry[0]] = entry[1];
     }
     return out;
   } catch {

--- a/lib/jwtAuth.ts
+++ b/lib/jwtAuth.ts
@@ -6,7 +6,6 @@ import { listLocalCompanies, listLocalLinksForUser, normalizeLocalRole, toLegacy
 import { hasForcedGlobalAccessForUser } from "@/lib/auth/specialAccess";
 import { resolveCapabilities } from "@/lib/permissions";
 import { resolvePermissionAccessForUser } from "@/lib/serverPermissionAccess";
-import { resolveVisibleCompanies } from "@/lib/companyVisibility";
 import type { PermissionMatrix } from "@/lib/permissionMatrix";
 
 export type AuthUser = {
@@ -25,85 +24,136 @@ export type AuthUser = {
   permissionRole?: string | null;
 };
 
-export async function authenticateRequest(req: Request): Promise<AuthUser | null> {
-  if (process.env.PLAYWRIGHT_MOCK === "true") {
-    const cookieHeader = req.headers.get("cookie") ?? "";
-    const rawCookie = cookieHeader
-      .split(";")
-      .map((part) => part.trim())
-      .find((part) => part.startsWith("e2e_auth="));
-    if (rawCookie) {
-      const encoded = rawCookie.slice("e2e_auth=".length);
-      try {
-        const decoded = JSON.parse(Buffer.from(decodeURIComponent(encoded), "base64url").toString("utf8")) as {
-          id?: string;
-          email?: string;
-          role?: string;
-          permissionRole?: string;
-          companyRole?: string;
-          companySlug?: string;
-          companySlugs?: string[];
-          isGlobalAdmin?: boolean;
-        };
+type LocalJwtUser = NonNullable<Awaited<ReturnType<typeof findUserByEmailOrId>>>;
+type LocalJwtLink = Awaited<ReturnType<typeof listLocalLinksForUser>>[number];
+type LocalJwtCompany = Awaited<ReturnType<typeof listLocalCompanies>>[number];
+type PlaywrightDecodedAuth = {
+  id?: string;
+  email?: string;
+  role?: string;
+  permissionRole?: string;
+  companyRole?: string;
+  companySlug?: string;
+  companySlugs?: string[];
+  isGlobalAdmin?: boolean;
+};
 
-        const companySlugs = Array.isArray(decoded.companySlugs)
-          ? decoded.companySlugs.filter((slug): slug is string => typeof slug === "string" && slug.trim().length > 0)
-          : decoded.companySlug
-            ? [decoded.companySlug]
-            : [];
+function readE2eAuthCookie(req: Request) {
+  const cookieHeader = req.headers.get("cookie") ?? "";
+  return cookieHeader
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("e2e_auth="));
+}
 
-        return {
-          id: decoded.id ?? "e2e-mock-user",
-          email: decoded.email ?? "e2e@testingcompany.local",
-          user: decoded.email ?? null,
-          isGlobalAdmin: decoded.isGlobalAdmin === true,
-          role: decoded.role ?? decoded.permissionRole ?? null,
-          globalRole: decoded.isGlobalAdmin === true ? "global_admin" : null,
-          companyRole: decoded.companyRole ?? decoded.role ?? null,
-          capabilities: [],
-          companyId: decoded.companySlug ?? null,
-          companySlug: decoded.companySlug ?? null,
-          companySlugs,
-          permissions: {},
-          permissionRole: decoded.permissionRole ?? decoded.role ?? null,
-        };
-      } catch {
-        // Ignore malformed e2e cookie and continue normal auth flow.
-      }
-    }
+function normalizeDecodedCompanySlugs(decoded: PlaywrightDecodedAuth) {
+  if (Array.isArray(decoded.companySlugs)) {
+    return decoded.companySlugs.filter(
+      (slug): slug is string => typeof slug === "string" && slug.trim().length > 0,
+    );
   }
+  return decoded.companySlug ? [decoded.companySlug] : [];
+}
 
+function buildPlaywrightAuthUser(decoded: PlaywrightDecodedAuth): AuthUser {
+  return {
+    id: decoded.id ?? "e2e-mock-user",
+    email: decoded.email ?? "e2e@testingcompany.local",
+    user: decoded.email ?? null,
+    isGlobalAdmin: decoded.isGlobalAdmin === true,
+    role: decoded.role ?? decoded.permissionRole ?? null,
+    globalRole: decoded.isGlobalAdmin === true ? "global_admin" : null,
+    companyRole: decoded.companyRole ?? decoded.role ?? null,
+    capabilities: [],
+    companyId: decoded.companySlug ?? null,
+    companySlug: decoded.companySlug ?? null,
+    companySlugs: normalizeDecodedCompanySlugs(decoded),
+    permissions: {},
+    permissionRole: decoded.permissionRole ?? decoded.role ?? null,
+  };
+}
+
+function parsePlaywrightAuthUser(req: Request): AuthUser | null {
+  if (process.env.PLAYWRIGHT_MOCK !== "true") return null;
+
+  const rawCookie = readE2eAuthCookie(req);
+  if (!rawCookie) return null;
+
+  try {
+    const encoded = rawCookie.slice("e2e_auth=".length);
+    const decoded = JSON.parse(
+      Buffer.from(decodeURIComponent(encoded), "base64url").toString("utf8"),
+    ) as PlaywrightDecodedAuth;
+    return buildPlaywrightAuthUser(decoded);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveAccessContextAuthUser(req: Request): Promise<AuthUser | null> {
   const access = await getAccessContext(req);
-  if (access) {
-    const permissionAccess = await resolvePermissionAccessForUser(access.userId);
-    return {
-      id: access.userId,
-      email: access.email,
-      user: access.user ?? null,
-      isGlobalAdmin: access.isGlobalAdmin,
-      role: access.role,
-      globalRole: access.globalRole ?? null,
-      companyRole: access.companyRole ?? null,
-      capabilities: access.capabilities ?? [],
-      companyId: access.companyId,
-      companySlug: access.companySlug,
-      companySlugs: access.companySlugs,
-      permissions: permissionAccess.permissions,
-      permissionRole: permissionAccess.roleKey,
-    };
-  }
+  if (!access) return null;
 
+  const permissionAccess = await resolvePermissionAccessForUser(access.userId);
+  return {
+    id: access.userId,
+    email: access.email,
+    user: access.user ?? null,
+    isGlobalAdmin: access.isGlobalAdmin,
+    role: access.role,
+    globalRole: access.globalRole ?? null,
+    companyRole: access.companyRole ?? null,
+    capabilities: access.capabilities ?? [],
+    companyId: access.companyId,
+    companySlug: access.companySlug,
+    companySlugs: access.companySlugs,
+    permissions: permissionAccess.permissions,
+    permissionRole: permissionAccess.roleKey,
+  };
+}
+
+function resolveRequestIdentifier(req: Request) {
   const headerAuth = req.headers.get("authorization");
-  let identifier: string | null = null;
   if (headerAuth?.toLowerCase().startsWith("bearer ")) {
-    identifier = headerAuth.slice("bearer ".length).trim();
+    return headerAuth.slice("bearer ".length).trim();
   }
-  if (!identifier) {
-    const url = new URL(req.url);
-    identifier = url.searchParams.get("user");
-  }
-  if (!identifier) return null;
 
+  const url = new URL(req.url);
+  return url.searchParams.get("user");
+}
+
+function localUserHasRole(user: LocalJwtUser, links: LocalJwtLink[], expectedRole: string) {
+  return (
+    normalizeLocalRole((user as { role?: string | null }).role ?? null) === expectedRole ||
+    links.some((link) => normalizeLocalRole(link.role ?? null) === expectedRole)
+  );
+}
+
+function isLocalGlobalAdmin(user: LocalJwtUser, hasForcedGlobalAccess: boolean) {
+  return (
+    hasForcedGlobalAccess ||
+    (user as { is_global_admin?: boolean; globalRole?: string | null }).is_global_admin === true ||
+    (user as { globalRole?: string | null }).globalRole === "global_admin"
+  );
+}
+
+function resolveAllowedLocalCompanies(
+  companies: LocalJwtCompany[],
+  links: LocalJwtLink[],
+  hasFullCompanyAccess: boolean,
+) {
+  return hasFullCompanyAccess
+    ? companies
+    : companies.filter((company) => links.some((link) => link.companyId === company.id));
+}
+
+function extractCompanySlugs(companies: LocalJwtCompany[]) {
+  return companies
+    .map((company) => company.slug)
+    .filter((slug): slug is string => typeof slug === "string" && slug.length > 0);
+}
+
+async function resolveLocalAuthUser(identifier: string): Promise<AuthUser | null> {
   const user = await findUserByEmailOrId(identifier);
   if (!user) return null;
 
@@ -113,26 +163,15 @@ export async function authenticateRequest(req: Request): Promise<AuthUser | null
     email: user.email,
     user: (user as { user?: string | null }).user ?? null,
   });
-  const isGlobalAdmin =
-    hasForcedGlobalAccess ||
-    (user as { is_global_admin?: boolean; globalRole?: string | null }).is_global_admin === true ||
-    (user as { globalRole?: string | null }).globalRole === "global_admin";
-  const hasTechnicalSupportRole =
-    normalizeLocalRole((user as { role?: string | null }).role ?? null) === "technical_support" ||
-    links.some((link) => normalizeLocalRole(link.role ?? null) === "technical_support");
-  const hasLeaderTcRole =
-    normalizeLocalRole((user as { role?: string | null }).role ?? null) === "leader_tc" ||
-    links.some((link) => normalizeLocalRole(link.role ?? null) === "leader_tc");
+  const isGlobalAdmin = isLocalGlobalAdmin(user, hasForcedGlobalAccess);
+  const hasTechnicalSupportRole = localUserHasRole(user, links, "technical_support");
+  const hasLeaderTcRole = localUserHasRole(user, links, "leader_tc");
   const hasFullCompanyAccess = hasForcedGlobalAccess || isGlobalAdmin || hasTechnicalSupportRole || hasLeaderTcRole;
   const shouldBindCompanyContext = !hasFullCompanyAccess;
-  const allowedCompanies = hasFullCompanyAccess
-    ? companies
-    : companies.filter((company) => links.some((link) => link.companyId === company.id));
+  const allowedCompanies = resolveAllowedLocalCompanies(companies, links, hasFullCompanyAccess);
   if (!hasFullCompanyAccess && allowedCompanies.length === 0) return null;
   const primary = shouldBindCompanyContext ? allowedCompanies[0] ?? null : null;
-  const companySlugs = allowedCompanies
-    .map((company) => company.slug)
-    .filter((slug): slug is string => typeof slug === "string" && slug.length > 0);
+  const companySlugs = extractCompanySlugs(allowedCompanies);
   const primaryLink = primary ? links.find((link) => link.companyId === primary.id) ?? null : null;
   const rawRole = primaryLink?.role ?? (user as { role?: string | null }).role ?? null;
   const normalizedRole = normalizeLocalRole(rawRole);
@@ -159,4 +198,15 @@ export async function authenticateRequest(req: Request): Promise<AuthUser | null
     permissions: permissionAccess.permissions,
     permissionRole: permissionAccess.roleKey,
   };
+}
+
+export async function authenticateRequest(req: Request): Promise<AuthUser | null> {
+  const mockUser = parsePlaywrightAuthUser(req);
+  if (mockUser) return mockUser;
+
+  const accessUser = await resolveAccessContextAuthUser(req);
+  if (accessUser) return accessUser;
+
+  const identifier = resolveRequestIdentifier(req);
+  return identifier ? resolveLocalAuthUser(identifier) : null;
 }

--- a/lib/manualReleaseResponsible.ts
+++ b/lib/manualReleaseResponsible.ts
@@ -43,28 +43,48 @@ function compareResponsibleOptions(
   return left.label.localeCompare(right.label, "pt-BR", { sensitivity: "base" });
 }
 
-export async function listManualReleaseResponsibleOptions(
-  companySlug?: string | null,
-  extraUserIds: Array<string | null | undefined> = [],
-) {
-  const extraIds = new Set(
+function buildExtraUserIdSet(extraUserIds: Array<string | null | undefined>) {
+  return new Set(
     extraUserIds
       .map((value) => (typeof value === "string" ? value.trim() : ""))
       .filter(Boolean),
   );
-  const allowedIds = new Set(extraIds);
+}
 
-  if (typeof companySlug === "string" && companySlug.trim()) {
-    const company = await findLocalCompanyBySlug(companySlug.trim());
-    if (company?.id) {
-      const links = await listLocalLinksForCompany(company.id);
-      for (const link of links) {
-        if (typeof link.userId === "string" && link.userId.trim()) {
-          allowedIds.add(link.userId.trim());
-        }
-      }
+async function addCompanyResponsibleIds(
+  allowedIds: Set<string>,
+  companySlug?: string | null,
+) {
+  if (typeof companySlug !== "string" || !companySlug.trim()) return;
+
+  const company = await findLocalCompanyBySlug(companySlug.trim());
+  if (!company?.id) return;
+
+  const links = await listLocalLinksForCompany(company.id);
+  for (const link of links) {
+    if (typeof link.userId === "string" && link.userId.trim()) {
+      allowedIds.add(link.userId.trim());
     }
   }
+}
+
+function canListResponsibleUser(
+  user: LocalAuthUser,
+  userId: string,
+  extraIds: Set<string>,
+) {
+  const isInactive = user.active === false || String(user.status ?? "").toLowerCase() === "blocked";
+  return !isInactive || extraIds.has(userId);
+}
+
+export async function listManualReleaseResponsibleOptions(
+  companySlug?: string | null,
+  extraUserIds: Array<string | null | undefined> = [],
+) {
+  const extraIds = buildExtraUserIdSet(extraUserIds);
+  const allowedIds = new Set(extraIds);
+
+  await addCompanyResponsibleIds(allowedIds, companySlug);
 
   if (allowedIds.size === 0) return [];
 
@@ -75,8 +95,7 @@ export async function listManualReleaseResponsibleOptions(
   for (const userId of allowedIds) {
     const user = usersById.get(userId);
     if (!user) continue;
-    const isInactive = user.active === false || String(user.status ?? "").toLowerCase() === "blocked";
-    if (isInactive && !extraIds.has(userId)) continue;
+    if (!canListResponsibleUser(user, userId, extraIds)) continue;
     options.push(buildResponsibleOption(user));
   }
 

--- a/lib/navigation/navigationContext.ts
+++ b/lib/navigation/navigationContext.ts
@@ -17,13 +17,13 @@ const MODULE_PATTERNS: Array<{ pattern: RegExp; module: NavModule }> = [
   { pattern: /^\/admin\/(brain)/, module: "brain" },
   { pattern: /^\/admin\/(users\/permissions|integrations|settings)/, module: "admin" },
   { pattern: /^\/automacoes/, module: "automation" },
-  { pattern: /^\/chat|\/conversas/, module: "brain" },
+  { pattern: /^\/(?:chat|conversas)/, module: "brain" },
   { pattern: /^\/kanban/, module: "operations" },
   { pattern: /^\/runs/, module: "quality" },
-  { pattern: /^\/documentos|\/documentacao/, module: "documents" },
-  { pattern: /^\/chamados|\/meus-chamados/, module: "support" },
-  { pattern: /^\/integrations|\/settings/, module: "admin" },
-  { pattern: /^\/home|^\/$/, module: "home" },
+  { pattern: /^\/(?:documentos|documentacao)/, module: "documents" },
+  { pattern: /^\/(?:chamados|meus-chamados)/, module: "support" },
+  { pattern: /^\/(?:integrations|settings)/, module: "admin" },
+  { pattern: /^(?:\/home|\/$)/, module: "home" },
 ];
 
 const COMPANY_SEGMENT_MAP: Record<string, NavModule> = {

--- a/lib/prismaClient.ts
+++ b/lib/prismaClient.ts
@@ -42,7 +42,7 @@ function recreatePrismaClient() {
   return client;
 }
 
-export let prisma: PrismaClient =
+let currentPrisma: PrismaClient =
   globalForPrisma.prisma ??
   (hasDatabaseUrl()
     ? createPrismaClient()
@@ -50,8 +50,22 @@ export let prisma: PrismaClient =
       ? createUnavailablePrismaClient()
       : createPrismaClient());
 
+function createPrismaClientProxy(): PrismaClient {
+  return new Proxy({} as PrismaClient, {
+    get(_target, prop) {
+      const value = Reflect.get(currentPrisma as object, prop, currentPrisma);
+      return typeof value === "function" ? value.bind(currentPrisma) : value;
+    },
+    set(_target, prop, value) {
+      return Reflect.set(currentPrisma as object, prop, value, currentPrisma);
+    },
+  });
+}
+
+export const prisma: PrismaClient = createPrismaClientProxy();
+
 if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
+  globalForPrisma.prisma = currentPrisma;
 }
 
 /**
@@ -60,5 +74,5 @@ if (process.env.NODE_ENV !== "production") {
  */
 export function reconnectPrisma() {
   console.info("[prisma] Reconnecting after connection loss...");
-  prisma = recreatePrismaClient();
+  currentPrisma = recreatePrismaClient();
 }

--- a/lib/qasePlans.ts
+++ b/lib/qasePlans.ts
@@ -178,6 +178,35 @@ function normalizeQaseCase(raw: unknown, projectCode: string): TestPlanCase | nu
   };
 }
 
+function normalizeAccessibleProject(entity: unknown): AccessibleProject | null {
+  if (!entity || typeof entity !== "object") return null;
+  const record = entity as Record<string, unknown>;
+  const code = normalizeString(record.code);
+  return code ? { code, title: normalizeString(record.title) } : null;
+}
+
+async function fetchAccessibleProjectsPage(
+  client: QaseClient,
+  limit: number,
+  offset: number,
+) {
+  const { data } = await client.getWithStatus<{ result?: { entities?: unknown[] } }>("/project", {
+    params: { limit, offset },
+    cache: "no-store",
+  });
+  return Array.isArray(data?.result?.entities) ? data.result.entities : [];
+}
+
+function addAccessibleProjects(
+  all: Map<string, AccessibleProject>,
+  entities: unknown[],
+) {
+  for (const entity of entities) {
+    const project = normalizeAccessibleProject(entity);
+    if (project) all.set(project.code, project);
+  }
+}
+
 async function listAccessibleProjects(client: QaseClient, token: string, baseUrl: string) {
   const cacheKey = `${baseUrl}:${token}`;
   const cache = getProjectsCache();
@@ -191,23 +220,10 @@ async function listAccessibleProjects(client: QaseClient, token: string, baseUrl
   let offset = 0;
 
   while (true) {
-    const { data } = await client.getWithStatus<{ result?: { entities?: unknown[] } }>("/project", {
-      params: { limit, offset },
-      cache: "no-store",
-    });
-    const entities = Array.isArray(data?.result?.entities) ? data.result.entities : [];
+    const entities = await fetchAccessibleProjectsPage(client, limit, offset);
     if (!entities.length) break;
 
-    for (const entity of entities) {
-      if (!entity || typeof entity !== "object") continue;
-      const record = entity as Record<string, unknown>;
-      const code = normalizeString(record.code);
-      if (!code) continue;
-      all.set(code, {
-        code,
-        title: normalizeString(record.title),
-      });
-    }
+    addAccessibleProjects(all, entities);
 
     if (entities.length < limit) break;
     offset += limit;

--- a/lib/qualityAlert.ts
+++ b/lib/qualityAlert.ts
@@ -15,6 +15,7 @@ const USE_MEMORY_ALERTS =
 
 const ALERTS_KEY = "qc:quality_alerts:v1";
 const USE_PERSISTENT_STORE = !USE_MEMORY_ALERTS && !USE_POSTGRES && canUsePersistentJsonStore();
+const ALERT_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 let memoryAlerts: QualityAlert[] = [];
 
@@ -159,6 +160,69 @@ async function safeFetch(input: RequestInfo, init?: RequestInit) {
   return fetch(input, init);
 }
 
+function isRecentDuplicateAlert(
+  now: string,
+  lastTimestamp: string | Date,
+  currentSeverity: QualityAlert["severity"],
+  lastSeverity: QualityAlert["severity"] | string,
+) {
+  return (
+    new Date(now).getTime() - new Date(lastTimestamp).getTime() < ALERT_DEDUP_WINDOW_MS &&
+    lastSeverity === currentSeverity
+  );
+}
+
+function resolveWebhookUrl(metadata?: Record<string, unknown>) {
+  return typeof metadata?.webhookUrl === "string" ? metadata.webhookUrl : null;
+}
+
+async function postQualityAlertWebhook(
+  webhookUrl: string | null,
+  alert: QualityAlert,
+) {
+  if (!webhookUrl) return;
+
+  try {
+    await safeFetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(alert),
+    });
+  } catch {
+    // Best-effort only.
+  }
+}
+
+async function sendPostgresQualityAlert(alert: QualityAlert) {
+  const prisma = await getPrisma();
+  const last = await prisma.qualityAlert.findFirst({
+    where: { companySlug: alert.companySlug, type: alert.type },
+    orderBy: { timestamp: "desc" },
+  });
+
+  if (
+    last &&
+    isRecentDuplicateAlert(alert.timestamp, last.timestamp, alert.severity, last.severity)
+  ) {
+    return false;
+  }
+
+  await prisma.qualityAlert.create({
+    data: {
+      companySlug: alert.companySlug,
+      type: alert.type,
+      severity: alert.severity,
+      message: alert.message,
+      metadata: alert.metadata
+        ? (alert.metadata as import("@prisma/client").Prisma.InputJsonValue)
+        : undefined,
+      timestamp: new Date(alert.timestamp),
+    },
+  });
+  await postQualityAlertWebhook(resolveWebhookUrl(alert.metadata), alert);
+  return true;
+}
+
 export async function sendQualityAlert({
   companySlug,
   type,
@@ -172,53 +236,21 @@ export async function sendQualityAlert({
     throw new Error(`Tipo de alerta invalido: ${type}`);
   }
 
+  const alert: QualityAlert = { companySlug, type, severity, message, metadata, timestamp: now };
+
   if (USE_POSTGRES && !USE_MEMORY_ALERTS) {
-    const prisma = await getPrisma();
-    // Dedup: check if same type+severity in last 24h
-    const last = await prisma.qualityAlert.findFirst({
-      where: { companySlug, type },
-      orderBy: { timestamp: "desc" },
-    });
-    if (last && new Date(now).getTime() - last.timestamp.getTime() < 24 * 60 * 60 * 1000 && last.severity === severity) {
-      return false;
-    }
-    await prisma.qualityAlert.create({
-      data: { companySlug, type, severity, message, metadata: metadata ? (metadata as import("@prisma/client").Prisma.InputJsonValue) : undefined, timestamp: new Date(now) },
-    });
-    const webhookUrl = metadata && typeof metadata.webhookUrl === "string" ? metadata.webhookUrl : null;
-    if (webhookUrl) {
-      try { await safeFetch(webhookUrl, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ companySlug, type, severity, message, metadata, timestamp: now }) }); } catch { /* best-effort */ }
-    }
-    return true;
+    return sendPostgresQualityAlert(alert);
   }
 
   const alerts = await readAlertsStore();
   const last = findLatestAlert(alerts, companySlug, type);
-  if (
-    last &&
-    new Date(now).getTime() - new Date(last.timestamp).getTime() < 24 * 60 * 60 * 1000 &&
-    last.severity === severity
-  ) {
+  if (last && isRecentDuplicateAlert(now, last.timestamp, severity, last.severity)) {
     return false;
   }
 
-  const alert: QualityAlert = { companySlug, type, severity, message, metadata, timestamp: now };
   alerts.push(alert);
   await writeAlertsStore(alerts);
-
-  const webhookUrl = metadata && typeof metadata.webhookUrl === "string" ? metadata.webhookUrl : null;
-  if (webhookUrl) {
-    try {
-      await safeFetch(webhookUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(alert),
-      });
-    } catch {
-      // Best-effort only.
-    }
-  }
-
+  await postQualityAlertWebhook(resolveWebhookUrl(metadata), alert);
   return true;
 }
 
@@ -276,4 +308,3 @@ export async function ensureSummaryAlerts(params: {
   }
   return results;
 }
-

--- a/lib/qualityGateHistory.ts
+++ b/lib/qualityGateHistory.ts
@@ -52,6 +52,27 @@ function pgRowToEntry(r: { id: string; companySlug: string; releaseSlug: string;
   };
 }
 
+function sortQualityGateHistory(
+  entries: QualityGateHistoryEntry[],
+): QualityGateHistoryEntry[] {
+  return [...entries].sort((a, b) =>
+    String(b.evaluated_at).localeCompare(String(a.evaluated_at)),
+  );
+}
+
+function filterQualityGateHistory(
+  entries: QualityGateHistoryEntry[],
+  companySlug?: string,
+  releaseSlug?: string,
+) {
+  return sortQualityGateHistory(
+    entries.filter((entry) => {
+      if (companySlug && entry.company_slug !== companySlug) return false;
+      return !(releaseSlug && entry.release_slug !== releaseSlug);
+    }),
+  );
+}
+
 export async function appendQualityGateHistory(entry: QualityGateHistoryEntry) {
   if (USE_MEMORY_ALERTS) {
     memoryStore = [...memoryStore, entry];
@@ -93,11 +114,7 @@ export async function readQualityGateHistory(
   releaseSlug?: string,
 ): Promise<QualityGateHistoryEntry[]> {
   if (USE_MEMORY_ALERTS) {
-    let arr = [...memoryStore];
-    if (companySlug) arr = arr.filter((i) => i.company_slug === companySlug);
-    if (releaseSlug) arr = arr.filter((i) => i.release_slug === releaseSlug);
-    arr.sort((a, b) => String(b.evaluated_at).localeCompare(String(a.evaluated_at)));
-    return arr;
+    return filterQualityGateHistory(memoryStore, companySlug, releaseSlug);
   }
 
   if (USE_POSTGRES) {
@@ -112,17 +129,14 @@ export async function readQualityGateHistory(
     return rows.map(pgRowToEntry);
   }
 
-  let arr: QualityGateHistoryEntry[] = [];
+  let entries: QualityGateHistoryEntry[] = [];
 
   if (USE_PERSISTENT_STORE) {
     const persisted = await readPersistentJson<QualityGateHistoryEntry[]>(STORE_KEY, []);
-    arr = Array.isArray(persisted) ? persisted : [];
+    entries = Array.isArray(persisted) ? persisted : [];
   } else {
-    arr = [...memoryStore];
+    entries = memoryStore;
   }
 
-  if (companySlug) arr = arr.filter((item) => item.company_slug === companySlug);
-  if (releaseSlug) arr = arr.filter((item) => item.release_slug === releaseSlug);
-  arr.sort((a, b) => String(b.evaluated_at).localeCompare(String(a.evaluated_at)));
-  return arr;
+  return filterQualityGateHistory(entries, companySlug, releaseSlug);
 }

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -203,7 +203,7 @@ function escapeRegex(value: string): string {
 
 type RedisClient = Redis | InMemoryRedis | PostgresRedis;
 
-let redis: RedisClient | null = null;
+let redisClient: RedisClient | null = null;
 let mockRedis: InMemoryRedis | null = null;
 let postgresRedis: PostgresRedis | null = null;
 let warnedRedisMissing = false;
@@ -234,7 +234,7 @@ function shouldUseMemoryFallback() {
 }
 
 export function getRedis() {
-  if (redis) return redis;
+  if (redisClient) return redisClient;
 
   const resolved = resolveRedisEnv();
   const url = resolved?.url;
@@ -243,33 +243,46 @@ export function getRedis() {
   if (!url || !token) {
     if (canUsePersistentFallback() && !shouldUseMemoryFallback()) {
       postgresRedis = postgresRedis ?? new PostgresRedis();
-      redis = postgresRedis;
+      redisClient = postgresRedis;
       if (!warnedRedisMissing) {
         warnedRedisMissing = true;
         console.warn(
           "[REDIS] Redis REST nao configurado; usando fallback persistente em PostgreSQL.",
         );
       }
-      return redis;
+      return redisClient;
     }
 
     mockRedis = mockRedis ?? new InMemoryRedis();
-    redis = mockRedis;
+    redisClient = mockRedis;
     if (!warnedRedisMissing) {
       warnedRedisMissing = true;
       console.warn(
         "[REDIS] UPSTASH_REDIS_REST_URL/TOKEN ou KV_REST_API_URL/TOKEN ausentes; usando fallback em memoria (nao persistente).",
       );
     }
-    return redis;
+    return redisClient;
   }
 
-  redis = new Redis({ url, token });
-  return redis;
+  redisClient = new Redis({ url, token });
+  return redisClient;
 }
 
-// For compatibility with old imports
-export { redis };
+function createRedisClientProxy(): RedisClient {
+  return new Proxy({} as RedisClient, {
+    get(_target, prop) {
+      const client = getRedis();
+      const value = Reflect.get(client as object, prop, client);
+      return typeof value === "function" ? value.bind(client) : value;
+    },
+    set(_target, prop, value) {
+      return Reflect.set(getRedis() as object, prop, value, getRedis());
+    },
+  });
+}
+
+// For compatibility with old imports.
+export const redis: RedisClient = createRedisClientProxy();
 
 export function isRedisConfigured(): boolean {
   return resolveRedisEnv() !== null || (canUsePersistentFallback() && !shouldUseMemoryFallback());

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -198,7 +198,7 @@ function patternToRegex(pattern: string): RegExp {
 }
 
 function escapeRegex(value: string): string {
-  return value.replace(/[-[\]{}()+?.,\\^$|#]/g, "\\$0");
+  return value.replace(/[-[\]{}()+?.,\\^$|#]/g, "\\$&");
 }
 
 type RedisClient = Redis | InMemoryRedis | PostgresRedis;

--- a/lib/runDetailViewModel.ts
+++ b/lib/runDetailViewModel.ts
@@ -13,6 +13,14 @@ import { formatRunText, formatRunTitle } from "@/lib/runPresentation";
 import type { Release } from "@/types/release";
 
 type AnyRelease = (Release & { name?: string }) | (ReleaseEntry & { name?: string });
+type RunStats = { pass: number; fail: number; blocked: number; notRun: number };
+type ResolvedReleaseData = {
+  source: "MANUAL" | "API";
+  releaseData: AnyRelease;
+  manualRelease: Release | null;
+};
+
+const EMPTY_RUN_STATS: RunStats = { pass: 0, fail: 0, blocked: 0, notRun: 0 };
 
 function parseQaseRunSlug(value: string): { projectCode: string; runId: number } | null {
   const trimmed = (value ?? "").trim();
@@ -23,6 +31,97 @@ function parseQaseRunSlug(value: string): { projectCode: string; runId: number }
   const runId = Number(match[2]);
   if (!projectCode || !Number.isFinite(runId)) return null;
   return { projectCode, runId };
+}
+
+async function findManualRelease(normalizedSlug: string) {
+  try {
+    const manualReleases = await readManualReleaseStore();
+    return manualReleases.find((release) => release.slug === normalizedSlug) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function buildQaseFallbackRelease(slug: string, normalizedSlug: string): ReleaseEntry | null {
+  const parsed = parseQaseRunSlug(slug);
+  if (!parsed) return null;
+
+  return {
+    slug: normalizedSlug,
+    title: `Run ${parsed.runId}`,
+    summary: "Execução integrada via Qase.",
+    runId: parsed.runId,
+    project: parsed.projectCode.toLowerCase(),
+    app: parsed.projectCode.toLowerCase(),
+    qaseProject: parsed.projectCode,
+  };
+}
+
+async function resolveReleaseData(
+  slug: string,
+  normalizedSlug: string,
+): Promise<ResolvedReleaseData | null> {
+  const manualRelease = await findManualRelease(normalizedSlug);
+  if (manualRelease) {
+    return { source: "MANUAL", releaseData: manualRelease as AnyRelease, manualRelease };
+  }
+
+  const apiRelease = (await getReleaseBySlug(normalizedSlug)) ?? buildQaseFallbackRelease(slug, normalizedSlug);
+  return apiRelease
+    ? { source: "API", releaseData: apiRelease as AnyRelease, manualRelease: null }
+    : null;
+}
+
+function hasRunStats(stats: RunStats) {
+  return stats.pass + stats.fail + stats.blocked + stats.notRun > 0;
+}
+
+function getInitialRunStats(source: "MANUAL" | "API", manualRelease: Release | null) {
+  return source === "MANUAL" ? manualRelease?.stats ?? EMPTY_RUN_STATS : EMPTY_RUN_STATS;
+}
+
+async function hydrateApiRunStats(input: {
+  companySlug?: string;
+  normalizedSlug: string;
+  projectCode: string;
+  runId: number;
+  runIdValid: boolean;
+  source: "MANUAL" | "API";
+  stats: RunStats;
+}) {
+  if (input.source !== "API" || !input.runIdValid) {
+    return { stats: input.stats, hasData: hasRunStats(input.stats) };
+  }
+
+  try {
+    const qaseSlugKey = input.companySlug ?? input.normalizedSlug;
+    const run = await getRunDetails(input.projectCode, input.runId, qaseSlugKey);
+    return run
+      ? {
+          stats: { pass: run.pass, fail: run.fail, blocked: run.blocked, notRun: run.notRun },
+          hasData: run.hasData,
+        }
+      : { stats: input.stats, hasData: hasRunStats(input.stats) };
+  } catch {
+    return { stats: input.stats, hasData: hasRunStats(input.stats) };
+  }
+}
+
+function buildApiPersistEndpoint(input: {
+  companySlug?: string;
+  projectCode: string;
+  runId: number;
+  runIdValid: boolean;
+  source: "MANUAL" | "API";
+}) {
+  if (input.source !== "API" || !input.runIdValid) return undefined;
+
+  const query = new URLSearchParams({
+    project: input.projectCode,
+    runId: String(input.runId),
+  });
+  if (input.companySlug) query.set("slug", input.companySlug);
+  return `/api/kanban?${query.toString()}`;
 }
 
 export type RunDetailViewModel = {
@@ -62,41 +161,11 @@ export async function getRunDetailViewModel(
   companySlug?: string,
 ): Promise<RunDetailViewModel | null> {
   const normalizedSlug = slugifyRelease(slug);
-  let manualRelease: Release | null = null;
-  let apiRelease: ReleaseEntry | null = null;
+  const resolvedRelease = await resolveReleaseData(slug, normalizedSlug);
 
-  try {
-    const manualReleases = await readManualReleaseStore();
-    manualRelease = manualReleases.find((r) => r.slug === normalizedSlug) ?? null;
-  } catch {
-    manualRelease = null;
-  }
+  if (!resolvedRelease) return null;
 
-  if (!manualRelease) {
-    apiRelease = (await getReleaseBySlug(normalizedSlug)) ?? null;
-  }
-
-  const source: "MANUAL" | "API" = manualRelease ? "MANUAL" : "API";
-  let releaseData: AnyRelease | null =
-    (manualRelease as AnyRelease) || (apiRelease as AnyRelease);
-
-  if (!releaseData) {
-    const parsed = parseQaseRunSlug(slug);
-    if (parsed) {
-      apiRelease = {
-        slug: normalizedSlug,
-        title: `Run ${parsed.runId}`,
-        summary: "Execução integrada via Qase.",
-        runId: parsed.runId,
-        project: parsed.projectCode.toLowerCase(),
-        app: parsed.projectCode.toLowerCase(),
-        qaseProject: parsed.projectCode,
-      };
-      releaseData = apiRelease as AnyRelease;
-    }
-  }
-
-  if (!releaseData) return null;
+  const { source, releaseData, manualRelease } = resolvedRelease;
 
   const projectKey = (
     releaseData.app || (releaseData as ReleaseEntry).project || "smart"
@@ -107,27 +176,22 @@ export async function getRunDetailViewModel(
   const appMeta = getAppMeta(projectKey, projectCode);
   const appColorClass = getAppColorClass(projectKey);
 
-  let stats =
-    source === "MANUAL"
-      ? manualRelease?.stats ?? { pass: 0, fail: 0, blocked: 0, notRun: 0 }
-      : { pass: 0, fail: 0, blocked: 0, notRun: 0 };
-  let hasData = stats.pass + stats.fail + stats.blocked + stats.notRun > 0;
+  let stats = getInitialRunStats(source, manualRelease);
 
   const runId = Number((releaseData as ReleaseEntry).runId);
   const runIdValid = Number.isFinite(runId);
 
-  if (source === "API" && runIdValid) {
-    const qaseSlugKey = companySlug ?? normalizedSlug;
-    try {
-      const run = await getRunDetails(projectCode, runId, qaseSlugKey);
-      if (run) {
-        stats = { pass: run.pass, fail: run.fail, blocked: run.blocked, notRun: run.notRun };
-        hasData = run.hasData;
-      }
-    } catch {
-      /* ignore */
-    }
-  }
+  const hydratedRun = await hydrateApiRunStats({
+    companySlug,
+    normalizedSlug,
+    projectCode,
+    runId,
+    runIdValid,
+    source,
+    stats,
+  });
+  stats = hydratedRun.stats;
+  const hasData = hydratedRun.hasData;
 
   const editable = source === "MANUAL";
   const total = stats.pass + stats.fail + stats.blocked + stats.notRun;
@@ -145,12 +209,13 @@ export async function getRunDetailViewModel(
   });
 
   const canPersistApiLinks = source === "API" && Boolean(companySlug);
-  const apiPersistEndpoint =
-    source === "API" && runIdValid
-      ? `/api/kanban?project=${encodeURIComponent(projectCode)}&runId=${encodeURIComponent(
-          String(runId ?? 0),
-        )}${companySlug ? `&slug=${encodeURIComponent(companySlug)}` : ""}`
-      : undefined;
+  const apiPersistEndpoint = buildApiPersistEndpoint({
+    companySlug,
+    projectCode,
+    runId,
+    runIdValid,
+    source,
+  });
 
   const displayTitle = formatRunTitle(
     (releaseData as { name?: string }).name ??

--- a/next.config.ts
+++ b/next.config.ts
@@ -78,7 +78,7 @@ const nextConfig = {
   webpack: (config: { watchOptions?: { ignored?: string[] } }, { dev }: { dev: boolean }) => {
     if (dev) {
       const ignored = new Set<string>([
-        ...(Array.isArray(config.watchOptions?.ignored) ? config.watchOptions?.ignored : []),
+        ...(Array.isArray(config.watchOptions?.ignored) ? config.watchOptions.ignored : []),
         "**/data/**",
       ]);
       config.watchOptions = { ...(config.watchOptions ?? {}), ignored: Array.from(ignored) };

--- a/scripts/audit-branches.js
+++ b/scripts/audit-branches.js
@@ -49,7 +49,7 @@ function collectFlags(paths) {
     }
   }
 
-  return Array.from(flags).sort();
+  return Array.from(flags).sort((a, b) => a.localeCompare(b));
 }
 
 function collectHotspots(paths) {

--- a/tests-e2e/fixtures/test-assets.fixture.ts
+++ b/tests-e2e/fixtures/test-assets.fixture.ts
@@ -68,7 +68,7 @@ type TestAssetsFixture = {
  *   await biometricPage.uploadFinger("right-index", pack.get("right_index").filePath);
  */
 export const test = base.extend<{ testAssets: TestAssetsFixture }>({
-  testAssets: async ({ request }, use) => {
+  testAssets: async ({ request }, provideFixture) => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "tc-assets-"));
 
     /**
@@ -226,7 +226,7 @@ export const test = base.extend<{ testAssets: TestAssetsFixture }>({
       return asset as ResolvedAsset & { filePath: string };
     }
 
-    await use({
+    await provideFixture({
       resolve,
       resolveAsBuffer,
       resolveAsBase64,

--- a/tests/brian-contextual-foundation.test.ts
+++ b/tests/brian-contextual-foundation.test.ts
@@ -9,6 +9,8 @@ import {
   processBrianImpulse,
 } from "@/lib/brain/contextual";
 
+const compareText = (left: string, right: string) => left.localeCompare(right);
+
 describe("Brian contextual foundation", () => {
   it("normalizes market/system aliases into canonical Brian contracts", () => {
     expect(normalizeImpulseType("bugCreated")).toBe("defect.created");
@@ -135,8 +137,12 @@ describe("Brian contextual foundation", () => {
     const second = processBrianImpulse(impulse, { applyRbac: false });
 
     expect(firstOutbox.idempotencyKey).toBe(secondOutbox.idempotencyKey);
-    expect(first.neurons.map((neuron) => neuron.id).sort()).toEqual(second.neurons.map((neuron) => neuron.id).sort());
-    expect(first.synapses.map((synapse) => synapse.id).sort()).toEqual(second.synapses.map((synapse) => synapse.id).sort());
+    expect(first.neurons.map((neuron) => neuron.id).sort(compareText)).toEqual(
+      second.neurons.map((neuron) => neuron.id).sort(compareText),
+    );
+    expect(first.synapses.map((synapse) => synapse.id).sort(compareText)).toEqual(
+      second.synapses.map((synapse) => synapse.id).sort(compareText),
+    );
   });
 
   it("requires policy-approved capabilities before sensitive Brian actions", () => {

--- a/tests/integration/company-integrations.test.ts
+++ b/tests/integration/company-integrations.test.ts
@@ -5,6 +5,7 @@ import { pgCreateLocalCompany, pgFindLocalCompanyBySlug } from "../../lib/core/a
 const uid = randomUUID().slice(0, 8);
 const COMPANY_NAME = `Empresa Integrações Teste ${uid}`;
 const COMPANY_SLUG = `empresa-integracoes-teste-${uid}`;
+const compareText = (left: string, right: string) => left.localeCompare(right);
 
 afterAll(async () => {
   await prisma.$disconnect();
@@ -34,8 +35,8 @@ describe("Company integrations persistence", () => {
     const dbRow = await prisma.company.findUnique({ where: { slug: COMPANY_SLUG }, include: { integrations: true } as any });
     expect(dbRow).not.toBeNull();
     const integrations = (dbRow?.integrations ?? []) as any[];
-    const types = integrations.map((i: any) => i.type).sort();
-    expect(types).toEqual(["JIRA", "QASE"].sort());
+    const types = integrations.map((i: any) => i.type).sort(compareText);
+    expect(types).toEqual(["JIRA", "QASE"].sort(compareText));
 
     const q = integrations.find((i: any) => i.type === "QASE");
     expect(q).toBeDefined();

--- a/tests/system-roles.test.ts
+++ b/tests/system-roles.test.ts
@@ -2,9 +2,11 @@ import { normalizeLegacyRole, SYSTEM_ROLES } from "../lib/auth/roles";
 import { ROLE_DEFAULTS } from "../lib/permissions/roleDefaults";
 import { canReviewAccessRequests, canReviewerAccessQueue } from "../lib/requestReviewAccess";
 
+const compareText = (left: string, right: string) => left.localeCompare(right);
+
 describe("system role contract", () => {
   it("exposes only the canonical profile roles", () => {
-    expect(Object.values(SYSTEM_ROLES).sort()).toEqual([
+    expect(Object.values(SYSTEM_ROLES).sort(compareText)).toEqual([
       "company_user",
       "empresa",
       "leader_tc",
@@ -14,7 +16,7 @@ describe("system role contract", () => {
   });
 
   it("keeps permission defaults keyed only by canonical roles", () => {
-    expect(Object.keys(ROLE_DEFAULTS).sort()).toEqual(Object.values(SYSTEM_ROLES).sort());
+    expect(Object.keys(ROLE_DEFAULTS).sort(compareText)).toEqual(Object.values(SYSTEM_ROLES).sort(compareText));
   });
 
   it("keeps access-request review capacity on leader TC, not support", () => {


### PR DESCRIPTION
## Summary
- Adds explicit localeCompare comparators to the sort calls flagged by SonarCloud.
- Covers app filters, project-code comparisons, branch audit flags, and affected tests.

## Verification
- npm run test:coverage
- npx eslint on the changed files (0 errors; existing warnings remain)