### PR TITLE
fix: configure SonarCloud scanner

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
 sonar.projectKey=AnaLysyk_Quality_Control
+sonar.organization=analysyk
 sonar.projectName=Quality Control
+sonar.host.url=https://sonarcloud.io
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=app,components,core,data,lib,packages,scripts,src


### PR DESCRIPTION
## Summary
- set SonarCloud organization for the project
- set SonarCloud host URL so local scanner no longer falls back to localhost:9000

## Validation
- npx sonar-scanner with a fake token reaches SonarCloud and fails at auth/project permission, confirming localhost is no longer used
- git diff --check