### PR TITLE
fix: address Sonar blocker findings

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -23,7 +23,6 @@ jobs:
       E2E_USE_JSON: "1"
       AUTH_STORE: "json"
       USE_JSON_STORE: "true"
-      DATABASE_URL: "postgresql://ci:ci@127.0.0.1:5432/ci?schema=public"
 
     steps:
       - name: Checkout repository

--- a/app/admin/access-requests/page.tsx
+++ b/app/admin/access-requests/page.tsx
@@ -310,6 +310,262 @@ const sectionCard =
 const sectionMuted =
   "rounded-3xl border border-(--tc-border) bg-(--tc-surface-2) p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)]";
 
+type StatusFilter = "all" | "open" | "in_progress" | "closed" | "rejected";
+type StatusCounters = {
+  approved: number;
+  inProgress: number;
+  inReview: number;
+  open: number;
+  rejected: number;
+  total: number;
+};
+
+function resolveViewerProfileLabel(user: ReturnType<typeof useAuthUser>["user"]) {
+  const permissionRole = typeof user?.permissionRole === "string" ? user.permissionRole : null;
+  const role = typeof user?.role === "string" ? user.role : null;
+  const companyRole = typeof user?.companyRole === "string" ? user.companyRole : null;
+  const normalizedRole =
+    normalizeRequestProfileType(permissionRole) ??
+    normalizeRequestProfileType(role) ??
+    normalizeRequestProfileType(companyRole);
+
+  if (normalizedRole === "technical_support") return "Suporte técnico";
+  if (normalizedRole === "leader_tc") return "Lider TC";
+  if (normalizedRole === "empresa") return "Empresa";
+  if (normalizedRole === "company_user") return "Usuário da empresa";
+  return "Painel institucional";
+}
+
+function filterAccessRequestItems(
+  items: AccessRequestItem[],
+  searchTerm: string,
+  statusFilter: StatusFilter,
+) {
+  const query = searchTerm.trim().toLowerCase();
+  return items.filter((item) => {
+    if (statusFilter !== "all" && item.status !== statusFilter) return false;
+    if (!query) return true;
+    return [
+      item.fullName,
+      item.name,
+      item.email,
+      item.company,
+      item.accessType,
+      item.jobRole,
+      item.title,
+    ]
+      .join(" ")
+      .toLowerCase()
+      .includes(query);
+  });
+}
+
+function calculateStatusCounters(items: AccessRequestItem[]): StatusCounters {
+  return items.reduce<StatusCounters>(
+    (acc, item) => {
+      acc.total += 1;
+      if (item.status === "open") {
+        acc.open += 1;
+        acc.inReview += 1;
+      }
+      if (item.status === "in_progress") {
+        acc.inProgress += 1;
+        acc.inReview += 1;
+      }
+      if (item.status === "closed") acc.approved += 1;
+      if (item.status === "rejected") acc.rejected += 1;
+      return acc;
+    },
+    { total: 0, open: 0, inReview: 0, inProgress: 0, approved: 0, rejected: 0 },
+  );
+}
+
+function getAdjustmentFieldOptions(
+  selected?: AccessRequestItem | null,
+  selectedOriginal?: AccessRequestSnapshot | null,
+) {
+  return selectedOriginal?.companyProfile || selected?.companyProfile
+    ? [...BASE_ADJUSTMENT_FIELD_OPTIONS, ...COMPANY_ADJUSTMENT_FIELD_OPTIONS]
+    : BASE_ADJUSTMENT_FIELD_OPTIONS;
+}
+
+function isAccessRequestDraftDirty(input: {
+  draft: Partial<AccessRequestItem> | null;
+  existingLogins: string[];
+  selected: AccessRequestItem | null;
+}) {
+  const { draft, existingLogins, selected } = input;
+  if (!selected || !draft) return false;
+  if (selected.requestKind === "password_reset" || draft.requestKind === "password_reset") return false;
+
+  const baselineUsername =
+    selected.username ??
+    buildUniqueUsername(selected.fullName || selected.name || selected.email, existingLogins, selected.username);
+
+  return (
+    (draft.accessType ?? "") !== (selected.accessType ?? "") ||
+    (draft.username ?? "") !== baselineUsername ||
+    (draft.clientId ?? "") !== (selected.clientId ?? "") ||
+    (draft.company ?? "") !== (selected.company ?? "") ||
+    (draft.fullName ?? "") !== (selected.fullName ?? "") ||
+    (draft.email ?? "") !== (selected.email ?? "") ||
+    (draft.phone ?? "") !== (selected.phone ?? "") ||
+    (draft.jobRole ?? "") !== (selected.jobRole ?? "") ||
+    (draft.title ?? "") !== (selected.title ?? "") ||
+    (draft.description ?? "") !== (selected.description ?? "") ||
+    (draft.adminNotes ?? "") !== (selected.adminNotes ?? "")
+  );
+}
+
+function hasMissingRequiredFields(
+  draft: Partial<AccessRequestItem> | null,
+  draftIsPasswordReset: boolean,
+) {
+  if (draftIsPasswordReset) return false;
+  return [
+    draft?.fullName,
+    draft?.username,
+    draft?.email,
+    draft?.phone,
+    draft?.jobRole,
+    draft?.title,
+    draft?.description,
+  ].some((value) => !String(value ?? "").trim()) || !draft?.passwordProvided;
+}
+
+function getEnvelopeRecord(raw: unknown) {
+  return (
+    unwrapEnvelopeData<Record<string, unknown>>(raw) ??
+    (raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {})
+  );
+}
+
+function getResponseErrorMessage(raw: unknown, response: Response, fallback: string) {
+  const msg = extractMessageFromJson(raw) || fallback;
+  const requestId = extractRequestIdFromJson(raw) || response.headers.get("x-request-id") || null;
+  return formatMessageWithRequestId(msg, requestId);
+}
+
+async function readJsonBody(response: Response) {
+  return response.json().catch(() => null);
+}
+
+function mapAccessRequestItem(r: RawSupportRequest): AccessRequestItem {
+  const parsedMsg = parseFromMessage(String(r.message ?? ""), String(r.email ?? ""));
+  return {
+    id: String(r.id),
+    createdAt: String(r.created_at),
+    status: String(r.status ?? "open"),
+    email: String(parsedMsg.email ?? r.email ?? ""),
+    name: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
+    fullName: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
+    username: typeof parsedMsg.username === "string" ? parsedMsg.username : null,
+    phone: String(parsedMsg.phone ?? ""),
+    jobRole: String(parsedMsg.jobRole ?? ""),
+    accessType: (parsedMsg.accessType as AccessTypeLabel) ?? "Usuário Testing Company",
+    clientId: parsedMsg.clientId ?? null,
+    company: String(parsedMsg.company ?? ""),
+    companyProfile: parsedMsg.companyProfile ?? null,
+    title: String(parsedMsg.title ?? ""),
+    description: String(parsedMsg.description ?? ""),
+    notes: String(parsedMsg.notes ?? ""),
+    passwordProvided: parsedMsg.passwordProvided === true,
+    originalRequest:
+      parsedMsg.originalRequest ??
+      ({
+        email: String(parsedMsg.email ?? r.email ?? ""),
+        name: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
+        fullName: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
+        username: typeof parsedMsg.username === "string" ? parsedMsg.username : null,
+        phone: String(parsedMsg.phone ?? ""),
+        passwordHash: null,
+        jobRole: String(parsedMsg.jobRole ?? ""),
+        company: String(parsedMsg.company ?? ""),
+        clientId: parsedMsg.clientId ?? null,
+        accessType: toInternalAccessType(normalizeRequestProfileType((parsedMsg.accessType as string) ?? "") ?? "testing_company_user"),
+        profileType: normalizeRequestProfileType((parsedMsg.accessType as string) ?? "") ?? "testing_company_user",
+        title: String(parsedMsg.title ?? ""),
+        description: String(parsedMsg.description ?? ""),
+        notes: String(parsedMsg.notes ?? ""),
+        companyProfile: parsedMsg.companyProfile ?? null,
+      } satisfies AccessRequestSnapshot),
+    adjustmentRound: parsedMsg.adjustmentRound ?? 0,
+    adjustmentRequestedFields: parsedMsg.adjustmentRequestedFields ?? [],
+    adjustmentHistory: parsedMsg.adjustmentHistory ?? [],
+    lastAdjustmentAt: typeof parsedMsg.lastAdjustmentAt === "string" ? parsedMsg.lastAdjustmentAt : null,
+    lastAdjustmentDiff: Array.isArray(parsedMsg.lastAdjustmentDiff) ? parsedMsg.lastAdjustmentDiff : [],
+    rawMessage: String(r.message ?? ""),
+    adminNotes: (r.admin_notes as string | null) ?? null,
+    requestKind: parsedMsg.requestKind ?? "access_request",
+    linkedRequestId: parsedMsg.linkedRequestId ?? null,
+  };
+}
+
+function mapClientOption(value: unknown): ClientOption | null {
+  const rec = (value ?? null) as Record<string, unknown> | null;
+  const id = typeof rec?.id === "string" ? rec.id : "";
+  const name =
+    (typeof rec?.name === "string" ? rec.name : "") ||
+    (typeof rec?.company_name === "string" ? String(rec.company_name) : "");
+  return id && name ? { id, name } : null;
+}
+
+function getClientOptions(raw: unknown) {
+  return getItemsFromEnvelope<unknown>(getEnvelopeRecord(raw))
+    .map(mapClientOption)
+    .filter((client): client is ClientOption => Boolean(client));
+}
+
+function getExistingLogins(raw: unknown) {
+  const userItems = getItemsFromEnvelope<UserLoginCandidate>(getEnvelopeRecord(raw));
+  return Array.from(
+    new Set(
+      userItems.flatMap((item) =>
+        [item.user, item.email]
+          .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+          .map((value) => value.trim().toLowerCase()),
+      ),
+    ),
+  );
+}
+
+async function loadAccessRequestsData() {
+  const [reqRes, clientsRes, usersRes] = await Promise.all([
+    fetchWithToken("/api/admin/access-requests"),
+    fetchWithToken("/api/clients"),
+    fetchWithToken("/api/admin/users"),
+  ]);
+
+  const reqRaw = await readJsonBody(reqRes);
+  if (!reqRes.ok) {
+    throw new Error(getResponseErrorMessage(reqRaw, reqRes, "Falha ao carregar solicitações"));
+  }
+
+  const clientsRaw = await readJsonBody(clientsRes);
+  const usersRaw = await readJsonBody(usersRes);
+
+  return {
+    clients: clientsRes.ok ? getClientOptions(clientsRaw) : [],
+    clientsError: clientsRes.ok ? null : getResponseErrorMessage(clientsRaw, clientsRes, "Falha ao carregar empresas"),
+    items: getItemsFromEnvelope<RawSupportRequest>(getEnvelopeRecord(reqRaw)).map(mapAccessRequestItem),
+    logins: getExistingLogins(usersRaw),
+  };
+}
+
+function getNextSelectedAccessRequestId(previousId: string | null, items: AccessRequestItem[]) {
+  return previousId && items.some((item) => item.id === previousId) ? previousId : items[0]?.id ?? null;
+}
+
+function debugLoadedAccessRequests(items: AccessRequestItem[]) {
+  try {
+    console.debug(
+      "[E2E][access-requests] carregou itens:",
+      items.length,
+      items.map((p) => ({ id: p.id, status: p.status })),
+    );
+  } catch {}
+}
+
 function AccessRequestsPage() {
   const { user } = useAuthUser();
   const [items, setItems] = useState<AccessRequestItem[]>([]);
@@ -329,23 +585,9 @@ function AccessRequestsPage() {
   const [commentLoading, setCommentLoading] = useState(false);
   const [commentError, setCommentError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"all" | "open" | "in_progress" | "closed" | "rejected">("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 
-  const viewerProfileLabel = useMemo(() => {
-    const permissionRole = typeof user?.permissionRole === "string" ? user.permissionRole : null;
-    const role = typeof user?.role === "string" ? user.role : null;
-    const companyRole = typeof user?.companyRole === "string" ? user.companyRole : null;
-    const normalizedRole =
-      normalizeRequestProfileType(permissionRole) ??
-      normalizeRequestProfileType(role) ??
-      normalizeRequestProfileType(companyRole);
-
-    if (normalizedRole === "technical_support") return "Suporte técnico";
-    if (normalizedRole === "leader_tc") return "Lider TC";
-    if (normalizedRole === "empresa") return "Empresa";
-    if (normalizedRole === "company_user") return "Usuário da empresa";
-    return "Painel institucional";
-  }, [user?.companyRole, user?.permissionRole, user?.role]);
+  const viewerProfileLabel = useMemo(() => resolveViewerProfileLabel(user), [user]);
 
   // Track whether the user has modified the draft form since the last selection change.
   // Prevents React Strict Mode double-invoke of load() from resetting user edits.
@@ -356,87 +598,32 @@ function AccessRequestsPage() {
     [items, selectedId],
   );
 
-  const filteredItems = useMemo(() => {
-    const query = searchTerm.trim().toLowerCase();
-    return items.filter((item) => {
-      const matchesStatus = statusFilter === "all" ? true : item.status === statusFilter;
-      if (!matchesStatus) return false;
-      if (!query) return true;
-      const haystack = [
-        item.fullName,
-        item.name,
-        item.email,
-        item.company,
-        item.accessType,
-        item.jobRole,
-        item.title,
-      ]
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(query);
-    });
-  }, [items, searchTerm, statusFilter]);
-
-  const statusCounters = useMemo(
-    () => ({
-      total: items.length,
-      open: items.filter((item) => item.status === "open").length,
-      inReview: items.filter((item) => item.status === "open" || item.status === "in_progress").length,
-      inProgress: items.filter((item) => item.status === "in_progress").length,
-      approved: items.filter((item) => item.status === "closed").length,
-      rejected: items.filter((item) => item.status === "rejected").length,
-    }),
-    [items],
+  const filteredItems = useMemo(
+    () => filterAccessRequestItems(items, searchTerm, statusFilter),
+    [items, searchTerm, statusFilter],
   );
+
+  const statusCounters = useMemo(() => calculateStatusCounters(items), [items]);
 
   const selectedAdjustmentDiff = selected?.lastAdjustmentDiff ?? [];
   const selectedHasRequesterAdjustment = Boolean(selected?.lastAdjustmentAt && selectedAdjustmentDiff.length > 0);
   const selectedOriginal = selected?.originalRequest ?? null;
   const latestAdjustmentRound = selected?.adjustmentHistory?.[selected.adjustmentHistory.length - 1] ?? null;
-  const adjustmentFieldOptions = useMemo(() => {
-    if (!selectedOriginal?.companyProfile && !selected?.companyProfile) {
-      return BASE_ADJUSTMENT_FIELD_OPTIONS;
-    }
-    return [...BASE_ADJUSTMENT_FIELD_OPTIONS, ...COMPANY_ADJUSTMENT_FIELD_OPTIONS];
-  }, [selected?.companyProfile, selectedOriginal?.companyProfile]);
-  const dirty = useMemo(() => {
-    if (!selected || !draft) return false;
-    if (selected.requestKind === "password_reset" || draft.requestKind === "password_reset") return false;
-
-    const baselineUsername =
-      selected.username ??
-      buildUniqueUsername(selected.fullName || selected.name || selected.email, existingLogins, selected.username);
-
-    return (
-      (draft.accessType ?? "") !== (selected.accessType ?? "") ||
-      (draft.username ?? "") !== baselineUsername ||
-      (draft.clientId ?? "") !== (selected.clientId ?? "") ||
-      (draft.company ?? "") !== (selected.company ?? "") ||
-      (draft.fullName ?? "") !== (selected.fullName ?? "") ||
-      (draft.email ?? "") !== (selected.email ?? "") ||
-      (draft.phone ?? "") !== (selected.phone ?? "") ||
-      (draft.jobRole ?? "") !== (selected.jobRole ?? "") ||
-      (draft.title ?? "") !== (selected.title ?? "") ||
-      (draft.description ?? "") !== (selected.description ?? "") ||
-      (draft.adminNotes ?? "") !== (selected.adminNotes ?? "")
-    );
-  }, [draft, existingLogins, selected]);
+  const adjustmentFieldOptions = useMemo(
+    () => getAdjustmentFieldOptions(selected, selectedOriginal),
+    [selected, selectedOriginal],
+  );
+  const dirty = useMemo(
+    () => isAccessRequestDraftDirty({ draft, existingLogins, selected }),
+    [draft, existingLogins, selected],
+  );
   const draftIsPasswordReset = draft?.requestKind === "password_reset";
   const selectedIsPasswordReset = selected?.requestKind === "password_reset";
   const draftProfileType =
     normalizeRequestProfileType((draft?.accessType ?? "Usuário Testing Company") as string) ?? "company_user";
   const requiresCompany = requestProfileTypeNeedsCompany(draftProfileType);
   const commentsLocked = selected?.status === "closed" || selected?.status === "rejected";
-  const missingRequiredFields =
-    !draftIsPasswordReset &&
-    (!String(draft?.fullName ?? "").trim() ||
-      !String(draft?.username ?? "").trim() ||
-      !String(draft?.email ?? "").trim() ||
-      !String(draft?.phone ?? "").trim() ||
-      !String(draft?.jobRole ?? "").trim() ||
-      !String(draft?.title ?? "").trim() ||
-      !String(draft?.description ?? "").trim() ||
-      !draft?.passwordProvided);
+  const missingRequiredFields = hasMissingRequiredFields(draft, draftIsPasswordReset);
   const acceptDisabled = !selected || !draft || accepting || missingRequiredFields || (requiresCompany && !draft.clientId);
 
   const load = useCallback(async () => {
@@ -445,122 +632,16 @@ function AccessRequestsPage() {
     setSuccessMessage(null);
 
     try {
-      const [reqRes, clientsRes, usersRes] = await Promise.all([
-        fetchWithToken("/api/admin/access-requests"),
-        fetchWithToken("/api/clients"),
-        fetchWithToken("/api/admin/users"),
-      ]);
-
-      const reqRaw = await reqRes.json().catch(() => null);
-      if (!reqRes.ok) {
-        const msg = extractMessageFromJson(reqRaw) || "Falha ao carregar solicitações";
-        const requestId = extractRequestIdFromJson(reqRaw) || reqRes.headers.get("x-request-id") || null;
-        setError(formatMessageWithRequestId(msg, requestId));
-        setItems([]);
-        return;
-      }
-
-      const reqData = unwrapEnvelopeData<Record<string, unknown>>(reqRaw) ?? (reqRaw as Record<string, unknown> | null) ?? {};
-      const rawItems = getItemsFromEnvelope<RawSupportRequest>(reqData);
-
-      const parsed: AccessRequestItem[] = rawItems.map((r) => {
-        const parsedMsg = parseFromMessage(String(r.message ?? ""), String(r.email ?? ""));
-        return {
-          id: String(r.id),
-          createdAt: String(r.created_at),
-          status: String(r.status ?? "open"),
-          email: String(parsedMsg.email ?? r.email ?? ""),
-          name: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
-          fullName: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
-          username: typeof parsedMsg.username === "string" ? parsedMsg.username : null,
-          phone: String(parsedMsg.phone ?? ""),
-          jobRole: String(parsedMsg.jobRole ?? ""),
-          accessType: (parsedMsg.accessType as AccessTypeLabel) ?? "Usuário Testing Company",
-          clientId: parsedMsg.clientId ?? null,
-          company: String(parsedMsg.company ?? ""),
-          companyProfile: parsedMsg.companyProfile ?? null,
-          title: String(parsedMsg.title ?? ""),
-          description: String(parsedMsg.description ?? ""),
-          notes: String(parsedMsg.notes ?? ""),
-          passwordProvided: parsedMsg.passwordProvided === true,
-          originalRequest:
-            parsedMsg.originalRequest ??
-            ({
-              email: String(parsedMsg.email ?? r.email ?? ""),
-              name: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
-              fullName: String(parsedMsg.fullName ?? parsedMsg.name ?? ""),
-              username: typeof parsedMsg.username === "string" ? parsedMsg.username : null,
-              phone: String(parsedMsg.phone ?? ""),
-              passwordHash: null,
-              jobRole: String(parsedMsg.jobRole ?? ""),
-              company: String(parsedMsg.company ?? ""),
-              clientId: parsedMsg.clientId ?? null,
-              accessType: toInternalAccessType(normalizeRequestProfileType((parsedMsg.accessType as string) ?? "") ?? "testing_company_user"),
-              profileType: normalizeRequestProfileType((parsedMsg.accessType as string) ?? "") ?? "testing_company_user",
-              title: String(parsedMsg.title ?? ""),
-              description: String(parsedMsg.description ?? ""),
-              notes: String(parsedMsg.notes ?? ""),
-              companyProfile: parsedMsg.companyProfile ?? null,
-            } satisfies AccessRequestSnapshot),
-          adjustmentRound: parsedMsg.adjustmentRound ?? 0,
-          adjustmentRequestedFields: parsedMsg.adjustmentRequestedFields ?? [],
-          adjustmentHistory: parsedMsg.adjustmentHistory ?? [],
-          lastAdjustmentAt: typeof parsedMsg.lastAdjustmentAt === "string" ? parsedMsg.lastAdjustmentAt : null,
-          lastAdjustmentDiff: Array.isArray(parsedMsg.lastAdjustmentDiff) ? parsedMsg.lastAdjustmentDiff : [],
-          rawMessage: String(r.message ?? ""),
-          adminNotes: (r.admin_notes as string | null) ?? null,
-          requestKind: parsedMsg.requestKind ?? "access_request",
-          linkedRequestId: parsedMsg.linkedRequestId ?? null,
-        };
-      });
-
-
-      const cRaw = await clientsRes.json().catch(() => null);
-      if (!clientsRes.ok) {
-        const msg = extractMessageFromJson(cRaw) || "Falha ao carregar empresas";
-        const requestId = extractRequestIdFromJson(cRaw) || clientsRes.headers.get("x-request-id") || null;
-        setError(formatMessageWithRequestId(msg, requestId));
-        setClients([]);
-      }
-
-      const cData = unwrapEnvelopeData<Record<string, unknown>>(cRaw) ?? (cRaw as Record<string, unknown> | null) ?? {};
-      const cItems = getItemsFromEnvelope<unknown>(cData);
-      const mappedClients = cItems
-        .map((c) => {
-          const rec = (c ?? null) as Record<string, unknown> | null;
-          return {
-            id: typeof rec?.id === "string" ? rec.id : "",
-            name:
-              (typeof rec?.name === "string" ? rec.name : "") ||
-              (typeof rec?.company_name === "string" ? String(rec.company_name) : ""),
-          };
-        })
-        .filter((c) => c.id && c.name);
-
-      const uRaw = await usersRes.json().catch(() => null);
-      const uData = unwrapEnvelopeData<Record<string, unknown>>(uRaw) ?? (uRaw as Record<string, unknown> | null) ?? {};
-      const uItems = getItemsFromEnvelope<UserLoginCandidate>(uData);
-      const mappedLogins = Array.from(
-        new Set(
-          uItems.flatMap((item) => {
-            const values = [item.user, item.email];
-            return values
-              .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-              .map((value) => value.trim().toLowerCase());
-          }),
-        ),
-      );
-
-      setClients(mappedClients);
-      setExistingLogins(mappedLogins);
-      setItems(parsed);
-      // Log para debugar E2E: quantos itens e status carregados
-      try {
-        console.debug("[E2E][access-requests] carregou itens:", parsed.length, parsed.map((p) => ({ id: p.id, status: p.status })));
-      } catch {}
-      setSelectedId((prev) => (prev && parsed.some((p) => p.id === prev) ? prev : parsed[0]?.id ?? null));
+      const data = await loadAccessRequestsData();
+      if (data.clientsError) setError(data.clientsError);
+      setClients(data.clients);
+      setExistingLogins(data.logins);
+      setItems(data.items);
+      debugLoadedAccessRequests(data.items);
+      setSelectedId((prev) => getNextSelectedAccessRequestId(prev, data.items));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro ao carregar");
+      setItems([]);
     } finally {
       setLoading(false);
     }

--- a/app/admin/audit-logs/page.tsx
+++ b/app/admin/audit-logs/page.tsx
@@ -401,6 +401,93 @@ const DATE_PRESETS: { value: DatePreset; label: string }[] = [
 ];
 
 const PAGE_SIZES = [25, 50, 100];
+const EMPTY_AUDIT_SUMMARY: AuditSummary = {
+  total: 0,
+  errorCount: 0,
+  authCount: 0,
+  uniqueActors: 0,
+  lastEventAt: null,
+};
+
+type AuditLogFilters = {
+  action: string;
+  actor: string;
+  category: ActionCategory | "";
+  currentPage: number;
+  endDate: string;
+  entityType: string;
+  pageSize: number;
+  query: string;
+  result: ResultFilter;
+  startDate: string;
+};
+
+type NormalizedAuditLogsResponse = {
+  actionOptions: FacetCount[];
+  actorNames: Record<string, string>;
+  avatars: Record<string, string>;
+  categoryCounts: Partial<Record<ActionCategory, number>>;
+  entityTypeOptions: FacetCount[];
+  items: AuditLog[];
+  retentionDays: number | null;
+  summary: AuditSummary;
+  topActions: FacetCount[];
+  total: number;
+  trend: TrendPoint[];
+  warning: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function setOptionalSearchParam(url: URL, key: string, value: string) {
+  if (value) url.searchParams.set(key, value);
+}
+
+function buildAuditLogsUrl(filters: AuditLogFilters) {
+  const url = new URL("/api/admin/audit-logs", window.location.origin);
+  url.searchParams.set("limit", String(filters.pageSize));
+  url.searchParams.set("offset", String((filters.currentPage - 1) * filters.pageSize));
+  setOptionalSearchParam(url, "action", filters.action);
+  setOptionalSearchParam(url, "entityType", filters.entityType);
+  setOptionalSearchParam(url, "category", filters.category);
+  setOptionalSearchParam(url, "result", filters.result);
+  setOptionalSearchParam(url, "actor", filters.actor);
+  setOptionalSearchParam(url, "query", filters.query);
+  setOptionalSearchParam(url, "startDate", filters.startDate);
+  setOptionalSearchParam(url, "endDate", filters.endDate);
+  return url;
+}
+
+async function readAuditLogsJson(response: Response) {
+  return response.json().catch(() => ({}));
+}
+
+function getAuditLogsErrorMessage(json: unknown) {
+  return isRecord(json) && typeof json.error === "string"
+    ? json.error
+    : "Não foi possível carregar o histórico";
+}
+
+function normalizeAuditLogsResponse(json: AuditLogsResponse): NormalizedAuditLogsResponse {
+  return {
+    items: Array.isArray(json?.items) ? (json.items as AuditLog[]) : [],
+    avatars: isRecord(json?.avatars) ? (json.avatars as Record<string, string>) : {},
+    actorNames: isRecord(json?.actorNames) ? (json.actorNames as Record<string, string>) : {},
+    warning: typeof json?.warning === "string" ? json.warning : null,
+    retentionDays: typeof json?.retentionDays === "number" ? json.retentionDays : null,
+    total: typeof json?.total === "number" ? json.total : 0,
+    summary: json?.summary ?? EMPTY_AUDIT_SUMMARY,
+    trend: Array.isArray(json?.trend) ? json.trend : [],
+    topActions: Array.isArray(json?.topActions) ? json.topActions : [],
+    categoryCounts: isRecord(json?.categoryCounts)
+      ? (json.categoryCounts as Partial<Record<ActionCategory, number>>)
+      : {},
+    actionOptions: Array.isArray(json?.facets?.actions) ? json.facets.actions : [],
+    entityTypeOptions: Array.isArray(json?.facets?.entityTypes) ? json.facets.entityTypes : [],
+  };
+}
 
 export default function AdminAuditLogsPage() {
   const [items, setItems] = useState<AuditLog[]>([]);
@@ -457,43 +544,36 @@ export default function AdminAuditLogsPage() {
     setError(null);
     setWarning(null);
     try {
-      const url = new URL("/api/admin/audit-logs", window.location.origin);
-      url.searchParams.set("limit", String(pageSize));
-      url.searchParams.set("offset", String((currentPage - 1) * pageSize));
-      if (action) url.searchParams.set("action", action);
-      if (entityType) url.searchParams.set("entityType", entityType);
-      if (categoryFilter) url.searchParams.set("category", categoryFilter);
-      if (resultFilter) url.searchParams.set("result", resultFilter);
-      if (deferredActor) url.searchParams.set("actor", deferredActor);
-      if (deferredSearchQuery) url.searchParams.set("query", deferredSearchQuery);
-      if (startDate) url.searchParams.set("startDate", startDate);
-      if (endDate) url.searchParams.set("endDate", endDate);
+      const url = buildAuditLogsUrl({
+        action,
+        actor: deferredActor,
+        category: categoryFilter,
+        currentPage,
+        endDate,
+        entityType,
+        pageSize,
+        query: deferredSearchQuery,
+        result: resultFilter,
+        startDate,
+      });
       const res = await fetch(url.toString(), { credentials: "include", cache: "no-store" });
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
-        throw new Error(typeof json?.error === "string" ? json.error : "Não foi possível carregar o histórico");
+        throw new Error(getAuditLogsErrorMessage(json));
       }
-      const json = (await res.json().catch(() => ({}))) as AuditLogsResponse;
-      setItems(Array.isArray(json?.items) ? (json.items as AuditLog[]) : []);
-      setAvatars(json?.avatars && typeof json.avatars === "object" ? (json.avatars as Record<string, string>) : {});
-      setActorNames(json?.actorNames && typeof json.actorNames === "object" ? (json.actorNames as Record<string, string>) : {});
-      setWarning(typeof json?.warning === "string" ? json.warning : null);
-      setRetentionDays(typeof json?.retentionDays === "number" ? json.retentionDays : null);
-      setTotal(typeof json?.total === "number" ? json.total : 0);
-      setSummary(
-        json?.summary ?? {
-          total: 0,
-          errorCount: 0,
-          authCount: 0,
-          uniqueActors: 0,
-          lastEventAt: null,
-        },
-      );
-      setTrend(Array.isArray(json?.trend) ? json.trend : []);
-      setTopActions(Array.isArray(json?.topActions) ? json.topActions : []);
-      setCategoryCounts(json?.categoryCounts && typeof json.categoryCounts === "object" ? json.categoryCounts : {});
-      setActionOptions(Array.isArray(json?.facets?.actions) ? json.facets.actions : []);
-      setEntityTypeOptions(Array.isArray(json?.facets?.entityTypes) ? json.facets.entityTypes : []);
+      const data = normalizeAuditLogsResponse((await readAuditLogsJson(res)) as AuditLogsResponse);
+      setItems(data.items);
+      setAvatars(data.avatars);
+      setActorNames(data.actorNames);
+      setWarning(data.warning);
+      setRetentionDays(data.retentionDays);
+      setTotal(data.total);
+      setSummary(data.summary);
+      setTrend(data.trend);
+      setTopActions(data.topActions);
+      setCategoryCounts(data.categoryCounts);
+      setActionOptions(data.actionOptions);
+      setEntityTypeOptions(data.entityTypeOptions);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Falha ao carregar histórico");
       setItems([]);
@@ -503,13 +583,7 @@ export default function AdminAuditLogsPage() {
       setCategoryCounts({});
       setActionOptions([]);
       setEntityTypeOptions([]);
-      setSummary({
-        total: 0,
-        errorCount: 0,
-        authCount: 0,
-        uniqueActors: 0,
-        lastEventAt: null,
-      });
+      setSummary(EMPTY_AUDIT_SUMMARY);
       setRetentionDays(null);
     } finally {
       setLoading(false);

--- a/app/docs/DocsWikiClient.tsx
+++ b/app/docs/DocsWikiClient.tsx
@@ -826,7 +826,7 @@ export default function DocsWikiClient({ basePath = "/api/platform-docs" }: { ba
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [basePath]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -894,7 +894,7 @@ export default function DocsWikiClient({ basePath = "/api/platform-docs" }: { ba
     setEditBlocks((prev) => {
       const arr = [...prev];
       const target = i + dir;
-      if (target < 0 || target >= arr.length) return arr;
+      if (target < 0 || target >= arr.length || i < 0 || i >= arr.length) return prev;
       [arr[i], arr[target]] = [arr[target], arr[i]];
       return arr;
     });


### PR DESCRIPTION
## Summary
- Removes the hard-coded PostgreSQL URL from the SonarCloud workflow.
- Refactors Sonar blocker/critical complexity findings in audit logs and access requests.
- Fixes the invariant return in DocsWiki block movement and the related hook dependency.

## Validation
- npx eslint app/docs/DocsWikiClient.tsx app/admin/audit-logs/page.tsx app/admin/access-requests/page.tsx
- npm exec --yes --package=eslint@9 --package=eslint-plugin-sonarjs --package=@typescript-eslint/parser -- eslint app/admin/access-requests/page.tsx app/admin/audit-logs/page.tsx --no-config-lookup --parser=@typescript-eslint/parser --plugin=sonarjs --rule="sonarjs/cognitive-complexity: [error, 15]"
- npm exec --yes --package=eslint@9 --package=eslint-plugin-sonarjs --package=@typescript-eslint/parser -- eslint app/docs/DocsWikiClient.tsx --no-config-lookup --parser=@typescript-eslint/parser --plugin=sonarjs --rule="sonarjs/no-invariant-returns: error"
- npm run test:coverage -- --runInBand
