### PR TITLE
fix: evitar prisma em projects no e2e json

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -20,6 +20,24 @@ export async function GET(request: Request) {
   const companySlug = searchParams.get("companySlug")?.trim();
   if (!companySlug) return NextResponse.json({ error: "companySlug obrigatório" }, { status: 400 });
 
+
+  if (process.env.E2E_USE_JSON === "1") {
+    return NextResponse.json({
+      projects: [
+        {
+          id: "e2e-project-testing-company",
+          slug: "quality-control",
+          name: "Quality Control",
+          description: "Projeto mockado para execucao E2E sem banco.",
+          status: "active",
+          color: "#2563eb",
+          iconKey: "folder",
+          companyId: companySlug,
+          createdAt: new Date(0).toISOString(),
+        },
+      ],
+    });
+  }
   const db = await getDb();
   const company = await db.company.findUnique({ where: { slug: companySlug }, select: { id: true } });
   if (!company) return NextResponse.json({ projects: [] });


### PR DESCRIPTION
## Resumo

- Ajusta o `GET /api/projects` para retornar um projeto mockado quando `E2E_USE_JSON=1`.
- Evita chamada ao Prisma durante execução E2E em modo JSON.
- Mantém o fluxo real com banco para ambientes fora do E2E JSON.

## Validação

```bash
npx playwright test tests-e2e/menu-reorganization.spec.ts --project=chromium
```

Resultado local:

```text
5 passed
0 failed
```

## Observação

Após o ajuste, o erro `Prisma client is unavailable (no DATABASE_URL) while E2E_USE_JSON=1 is active` não apareceu mais nessa execução. Permanecem apenas logs esperados de ambiente sem Redis/QASE configurados.