### PR TITLE
[codex] redireciona rota legada de solicitações

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -38,7 +38,8 @@ export default async function AdminLayout({ children }: { children: ReactNode })
   );
   const canOpenAdminRoute =
     hasAdminAccess ||
-    (hasAccessRequestsAccess && pathname.startsWith("/admin/access-requests"));
+    (hasAccessRequestsAccess &&
+      (pathname.startsWith("/admin/access-requests") || pathname.startsWith("/admin/requests")));
 
   if (!canOpenAdminRoute) {
     const fallbackCompany = access.companySlug ?? access.companySlugs[0] ?? null;

--- a/app/admin/requests/page.tsx
+++ b/app/admin/requests/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+
+type PageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function toQueryString(params?: Record<string, string | string[] | undefined>) {
+  if (!params) return "";
+  const query = new URLSearchParams();
+
+  for (const [key, rawValue] of Object.entries(params)) {
+    if (Array.isArray(rawValue)) {
+      for (const value of rawValue) {
+        if (typeof value === "string" && value.length > 0) query.append(key, value);
+      }
+      continue;
+    }
+
+    if (typeof rawValue === "string" && rawValue.length > 0) {
+      query.set(key, rawValue);
+    }
+  }
+
+  const serialized = query.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+export default async function LegacyAdminRequestsPage({ searchParams }: PageProps) {
+  const resolved = searchParams ? await searchParams : undefined;
+  redirect(`/admin/access-requests${toQueryString(resolved)}`);
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -192,7 +192,14 @@ export function proxy(request: NextRequest) {
 
   if (pathname === "/solicitacoes") {
     const url = request.nextUrl.clone();
-    url.pathname = "/admin/requests";
+    url.pathname = "/admin/access-requests";
+    url.search = search;
+    return NextResponse.redirect(url);
+  }
+
+  if (pathname === "/admin/requests") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/admin/access-requests";
     url.search = search;
     return NextResponse.redirect(url);
   }

--- a/support/functions/ui/login/solicitar-acesso/solicitacoes/operar-tela-solicitacoes.ts
+++ b/support/functions/ui/login/solicitar-acesso/solicitacoes/operar-tela-solicitacoes.ts
@@ -38,14 +38,15 @@ export async function validarAcessoNegadoAoModuloSolicitacoes(page: Page) {
   });
 }
 
-export async function validarRotaRemovidaNaoExiste(page: Page) {
+export async function validarRotaLegadaRedirecionaParaSolicitacoes(page: Page) {
   const response = await page.goto("/admin/requests", {
     waitUntil: "domcontentloaded",
   });
 
   expect(response?.status()).not.toBe(500);
+  await expect(page).toHaveURL(/\/admin\/access-requests/);
 
-  await expect(page.getByRole("heading", { name: /Solicitações de acesso/i })).not.toBeVisible({
-    timeout: 3000,
+  await expect(page.getByRole("heading", { name: /Solicitações de acesso/i })).toBeVisible({
+    timeout: 60000,
   });
 }

--- a/testes/ui/login/solicitar-acesso/gestao-solicitacoes/permissao/validar-acesso-modulo-solicitacoes-por-perfil.ui.spec.ts
+++ b/testes/ui/login/solicitar-acesso/gestao-solicitacoes/permissao/validar-acesso-modulo-solicitacoes-por-perfil.ui.spec.ts
@@ -12,7 +12,7 @@ import {
 import {
   abrirModuloSolicitacoes,
   validarAcessoNegadoAoModuloSolicitacoes,
-  validarRotaRemovidaNaoExiste,
+  validarRotaLegadaRedirecionaParaSolicitacoes,
   validarTelaSolicitacoes,
 } from "../../../../../../support/functions/ui/login/solicitar-acesso/solicitacoes/operar-tela-solicitacoes";
 
@@ -72,13 +72,13 @@ test.describe("Solicitações - acesso por perfil - UI", () => {
     });
   });
 
-  test("rota antiga /admin/requests não deve existir como fluxo válido", async ({
+  test("rota antiga /admin/requests deve redirecionar para Solicitações", async ({
     context,
     page,
   }) => {
     await autenticarSolicitacaoAcessoNaInterface(page, "leader_tc");
     await page.close();
     const oldRoutePage = await context.newPage();
-    await validarRotaRemovidaNaoExiste(oldRoutePage);
+    await validarRotaLegadaRedirecionaParaSolicitacoes(oldRoutePage);
   });
 });


### PR DESCRIPTION
## Resumo
- redireciona a rota legada `/admin/requests` para `/admin/access-requests`
- corrige o atalho `/solicitacoes` para apontar para a tela can�nica de Solicita��es
- adiciona fallback no App Router para a rota legada e atualiza o teste de compatibilidade

## Valida��o
- `npm run typecheck -- --pretty false`
- `npx playwright test testes/ui/login/solicitar-acesso/gestao-solicitacoes/permissao/validar-acesso-modulo-solicitacoes-por-perfil.ui.spec.ts --project=chromium --workers=1 --grep "rota antiga" --reporter=list`
- `git diff --check`
