### PR TITLE
[codex] preserva cache runtime com Next dev ativo

### DIFF
--- a/support/functions/infraestrutura/compilacao/limpar-cache-next.js
+++ b/support/functions/infraestrutura/compilacao/limpar-cache-next.js
@@ -1,5 +1,9 @@
 const fs = require("fs");
 const path = require("path");
+const { execFileSync } = require("child_process");
+
+const root = process.cwd();
+const isWin = process.platform === "win32";
 
 function removePath(target) {
   fs.rmSync(target, {
@@ -10,8 +14,104 @@ function removePath(target) {
   });
 }
 
+function readActiveNextDevPidsWindows() {
+  const escapedRoot = root.replace(/'/g, "''");
+  const currentPid = process.pid;
+  const cmd = `
+$ErrorActionPreference='SilentlyContinue'
+$root='${escapedRoot}'
+$currentPid=${currentPid}
+Get-CimInstance Win32_Process |
+  Where-Object {
+    $_.ProcessId -ne $currentPid -and
+    $_.Name -eq 'node.exe' -and
+    $_.CommandLine -and
+    ($_.CommandLine -like ('*' + $root + '*node_modules\\next\\dist\\*')) -and
+    ($_.CommandLine -match '(\\s|^)dev(\\s|$)')
+  } |
+  Select-Object -ExpandProperty ProcessId
+`;
+
+  try {
+    return execFileSync("powershell", ["-NoProfile", "-Command", cmd], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => Number(line))
+      .filter((value) => Number.isFinite(value));
+  } catch {
+    return [];
+  }
+}
+
+function readActiveNextDevPidsPosix() {
+  try {
+    return execFileSync("ps", ["-eo", "pid=,args="], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => {
+        const match = line.match(/^(\d+)\s+(.+)$/);
+        if (!match) return [];
+        const pid = Number(match[1]);
+        const command = match[2];
+        if (
+          pid === process.pid ||
+          !command.includes(root) ||
+          !command.includes("node_modules/next/dist") ||
+          !/(^|\s)dev(\s|$)/.test(command)
+        ) {
+          return [];
+        }
+        return [pid];
+      });
+  } catch {
+    return [];
+  }
+}
+
+function readActiveNextDevPids() {
+  return isWin ? readActiveNextDevPidsWindows() : readActiveNextDevPidsPosix();
+}
+
+function cleanGeneratedTypesOnly() {
+  for (const target of [
+    path.resolve(root, ".next", "types"),
+    path.resolve(root, ".next", "dev", "types"),
+    path.resolve(root, ".next", "dev", "dev", "types"),
+    path.resolve(root, ".next", "dev-runtime", "types"),
+    path.resolve(root, ".next", "dev-runtime", "dev", "types"),
+    path.resolve(root, ".next", "dev-runtime", "dev", "dev", "types"),
+    path.resolve(root, ".next-e2e", "types"),
+    path.resolve(root, ".next-e2e", "dev", "types"),
+  ]) {
+    if (path.relative(root, target).startsWith("..") || !fs.existsSync(target)) continue;
+    try {
+      removePath(target);
+    } catch (error) {
+      console.warn(`Nao foi possivel remover tipos gerados em ${target}; seguindo.`, error);
+    }
+  }
+}
+
 function cleanNext() {
-  const root = process.cwd();
+  const activeDevPids = readActiveNextDevPids();
+  if (activeDevPids.length > 0 && process.env.FORCE_NEXT_CACHE_CLEAN !== "1") {
+    cleanGeneratedTypesOnly();
+    console.warn(
+      `[next-cache] Next dev ativo neste repositorio (PID ${activeDevPids.join(", ")}). ` +
+        "Limpando apenas tipos gerados e preservando manifests/packs do servidor em execucao. " +
+        "Pare o servidor ou defina FORCE_NEXT_CACHE_CLEAN=1 para forcar.",
+    );
+    return;
+  }
+
   const cacheDirs = [".next", ".next-e2e", ".next-runtime", ".next-dev-runtime"];
 
   for (const cacheDir of cacheDirs) {


### PR DESCRIPTION
## Resumo
- evita que o script de limpeza apague `.next` quando h� `next dev` ativo no mesmo reposit�rio
- nesse caso, remove apenas tipos gerados do Next, preservando manifests e packs de runtime
- mant�m op��o de for�a via `FORCE_NEXT_CACHE_CLEAN=1`

## Motivo
O log do `npm run dev` mostrava ENOENT em `.next/dev/routes-manifest.json`, `app-paths-manifest.json`, `_document.js` e packs do webpack. Isso acontece quando a pasta `.next` � limpa enquanto o servidor dev ainda est� rodando.

## Valida��o
- `npm run typecheck -- --pretty false` com `next dev` ativo
- `curl.exe -I -L --max-redirs 3 http://localhost:3000/admin/requests`
- `curl.exe -I -L --max-redirs 3 http://localhost:3000/admin/access-requests`
- `git diff --check`
