### PR TITLE
test(users): criação de usuários por perfil e validação de Meu Perfil

### DIFF
--- a/support/functions/ui/login/solicitar-acesso/consulta/executar-consulta-status-por-perfil.ts
+++ b/support/functions/ui/login/solicitar-acesso/consulta/executar-consulta-status-por-perfil.ts
@@ -1,4 +1,4 @@
-﻿import { expect, type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 import {
   criarEmailTeste,
@@ -65,6 +65,28 @@ async function abrirFormularioConsultaPublica(page: Page) {
   await expect(formulario).toBeVisible({ timeout: 30000 });
 }
 
+async function esperarFormularioConsultaHidratado(page: Page) {
+  const formulario = page.getByTestId("access-request-lookup-form");
+
+  await expect(formulario).toBeVisible({ timeout: 30000 });
+
+  await expect
+    .poll(
+      () =>
+        formulario.evaluate((element) => {
+          const propsKey = Object.keys(element).find((key) => key.startsWith("__reactProps$"));
+          const props = propsKey
+            ? (element as unknown as Record<string, Record<string, unknown>>)[propsKey]
+            : null;
+          return typeof props?.onSubmit === "function";
+        }),
+      {
+        message: "Esperando o formulário de consulta concluir a hidratação.",
+        timeout: 60000,
+      },
+    )
+    .toBe(true);
+}
 export async function executarConsultaStatusSolicitacaoPorPerfil(page: Page, perfil: PerfilSolicitacao) {
   const email = criarEmailTeste(`visual-${perfil.value}`);
 
@@ -104,6 +126,15 @@ export async function executarConsultaStatusSolicitacaoPorPerfil(page: Page, per
 
   const respostaSubmit = await respostaSubmitPromise;
   const corpoSubmit = await respostaSubmit.text().catch(() => "");
+  const payloadSubmit = JSON.parse(corpoSubmit) as {
+    item?: {
+      accessKey?: string;
+      requesterName?: string;
+      requesterEmail?: string;
+    };
+  };
+  const nomeConsulta = payloadSubmit.item?.requesterName?.trim() || dadosPreenchidos.nomeCompleto;
+  const emailConsulta = payloadSubmit.item?.requesterEmail?.trim().toLowerCase() || email;
 
   console.log("[VISUAL][SOLICITAR-ACESSO]", {
     perfil: perfil.value,
@@ -135,16 +166,63 @@ export async function executarConsultaStatusSolicitacaoPorPerfil(page: Page, per
 
   await abrirFormularioConsultaPublica(page);
 
-  await page.getByTestId("request-access-lookup-name-input").fill(dadosPreenchidos.nomeCompleto);
-  await page.getByTestId("request-access-lookup-email-input").fill(email);
+  await page.getByTestId("request-access-lookup-name-input").fill(nomeConsulta);
+  await page.getByTestId("request-access-lookup-email-input").fill(emailConsulta);
   await page.getByTestId("request-access-lookup-code-input").fill(chave);
 
   await passo(`Consulta pública preenchida para ${perfil.labelTelaStatus}`, page);
 
-  await page.getByTestId("request-access-lookup-submit-button").click();
+  await esperarFormularioConsultaHidratado(page);
 
-  await expect(page).toHaveURL(/\/login\/access-request\/status\?key=/, {
+  const botaoConsultar = page.getByTestId("request-access-lookup-submit-button");
+  await expect(botaoConsultar).toBeEnabled({ timeout: 30000 });
+
+  const aguardarRespostaConsulta = () =>
+    page.waitForResponse(
+      (response) =>
+        response.url().includes(`/api/access-requests/by-key/${encodeURIComponent(chave)}`),
+      { timeout: 30000 },
+    );
+
+  let respostaConsulta = await Promise.all([
+    aguardarRespostaConsulta().catch(() => null),
+    botaoConsultar.click(),
+  ]).then(([response]) => response);
+
+  if (!respostaConsulta) {
+    const formularioConsulta = page.getByTestId("access-request-lookup-form");
+
+    respostaConsulta = await Promise.all([
+      aguardarRespostaConsulta().catch(() => null),
+      formularioConsulta.evaluate((form) => {
+        if (form instanceof HTMLFormElement) {
+          form.requestSubmit();
+        }
+      }),
+    ]).then(([response]) => response);
+  }
+
+  expect(respostaConsulta, "A consulta pública deve chamar a API by-key").not.toBeNull();
+
+  const corpoConsulta = await respostaConsulta!.text().catch(() => "");
+  expect(respostaConsulta!.ok(), corpoConsulta).toBe(true);
+
+  await page.waitForURL(/\/login\/access-request\/status\?key=/, {
     timeout: 90000,
+    waitUntil: "domcontentloaded",
+  }).catch(async (error) => {
+    const bodyText = await page.locator("body").innerText().catch(() => "");
+    console.log("[VISUAL][LOOKUP][FALHA]", {
+      perfil: perfil.value,
+      url: page.url(),
+      nomeConsulta,
+      emailConsulta,
+      chave,
+      consultaStatus: respostaConsulta?.status(),
+      consultaBody: corpoConsulta.slice(0, 2000),
+      body: bodyText.slice(0, 2000),
+    });
+    throw error;
   });
 
   await expect(page.getByTestId("access-request-status-result")).toBeVisible({

--- a/support/functions/ui/usuarios/validar-meu-perfil-usuario-criado.ts
+++ b/support/functions/ui/usuarios/validar-meu-perfil-usuario-criado.ts
@@ -1,0 +1,45 @@
+import { expect, type Page } from "@playwright/test";
+import { BASE_URL } from "../../api/autenticacao/autenticar-por-cookie";
+
+async function paginaTemCampoComValor(page: Page, valor: string) {
+  return page.locator("input, textarea").evaluateAll(
+    (elements, expected) =>
+      elements.some((element) => {
+        const field = element as HTMLInputElement | HTMLTextAreaElement;
+        return field.value.trim() === expected;
+      }),
+    valor,
+  );
+}
+
+export async function validarMeuPerfilUsuarioCriado(
+  page: Page,
+  dados: {
+    name: string;
+    email: string;
+  },
+) {
+  await page.goto("/settings/profile", { waitUntil: "domcontentloaded" });
+
+  await expect(page).not.toHaveURL(/\/login/);
+
+  const meResponse = await page.request.get(`${BASE_URL}/api/me`);
+  expect(meResponse.ok()).toBeTruthy();
+
+  const me = await meResponse.json();
+  expect(me.user.email).toBe(dados.email);
+
+  await expect
+    .poll(() => paginaTemCampoComValor(page, dados.name), {
+      message: `Meu Perfil deve exibir o nome ${dados.name}`,
+      timeout: 30000,
+    })
+    .toBe(true);
+
+  await expect
+    .poll(() => paginaTemCampoComValor(page, dados.email), {
+      message: `Meu Perfil deve exibir o e-mail ${dados.email}`,
+      timeout: 30000,
+    })
+    .toBe(true);
+}

--- a/testes/ui/usuarios/criar-usuario/empresa/criar-admin-empresa.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/empresa/criar-admin-empresa.ui.spec.ts
@@ -1,0 +1,49 @@
+﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
+import {
+  SENHA_USUARIO_NOVO,
+  aguardarUsuarioNaListaAdmin,
+  autenticarAdminParaCriacaoUsuario,
+  criarUsuarioViaApi,
+  loginDiretoUsuarioCriado,
+  validarSessaoUsuarioCriado,
+  temEmpresaE2E,
+} from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+
+test.setTimeout(180000);
+
+test.describe("Criar usuário - Admin da empresa", () => {
+  const createdUserIds: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdUserIds) {
+      await request.delete(`${BASE_URL}/api/admin/users/${id}`).catch(() => {});
+    }
+  });
+
+  test("cria Admin da empresa, lista o usuário, valida login e vínculo com empresa", async ({ page }) => {
+    const suffix = `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+    const email = `e2e-admin-empresa-${suffix}@demo.test`;
+    const name = `Teste Admin Empresa ${suffix}`;
+
+    await autenticarAdminParaCriacaoUsuario(page);
+
+    const created = await criarUsuarioViaApi(page, {
+      name,
+      email,
+      role: "empresa",
+      companySlug: "DEMO",
+      password: SENHA_USUARIO_NOVO,
+    });
+
+    if (created.id) createdUserIds.push(created.id);
+
+    await aguardarUsuarioNaListaAdmin(page, email);
+
+    await page.context().clearCookies();
+    await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    const me = await validarSessaoUsuarioCriado(page, email, "empresa");
+    expect(temEmpresaE2E(me)).toBeTruthy();
+  });
+});

--- a/testes/ui/usuarios/criar-usuario/empresa/criar-admin-empresa.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/empresa/criar-admin-empresa.ui.spec.ts
@@ -1,4 +1,4 @@
-﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { test, expect } from "../../../../../support/fixtures/test";
 import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
 import {
   SENHA_USUARIO_NOVO,
@@ -9,6 +9,7 @@ import {
   validarSessaoUsuarioCriado,
   temEmpresaE2E,
 } from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+import { validarMeuPerfilUsuarioCriado } from "../../../../../support/functions/ui/usuarios/validar-meu-perfil-usuario-criado";
 
 test.setTimeout(180000);
 
@@ -42,6 +43,8 @@ test.describe("Criar usuário - Admin da empresa", () => {
 
     await page.context().clearCookies();
     await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await validarMeuPerfilUsuarioCriado(page, { name, email });
 
     const me = await validarSessaoUsuarioCriado(page, email, "empresa");
     expect(temEmpresaE2E(me)).toBeTruthy();

--- a/testes/ui/usuarios/criar-usuario/lider-tc/criar-lider-tc.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/lider-tc/criar-lider-tc.ui.spec.ts
@@ -1,4 +1,4 @@
-﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { test, expect } from "../../../../../support/fixtures/test";
 import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
 import {
   SENHA_USUARIO_NOVO,
@@ -7,6 +7,7 @@ import {
   criarUsuarioViaApi,
   loginDiretoUsuarioCriado,
 } from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+import { validarMeuPerfilUsuarioCriado } from "../../../../../support/functions/ui/usuarios/validar-meu-perfil-usuario-criado";
 
 test.setTimeout(180000);
 
@@ -39,6 +40,8 @@ test.describe("Criar usuário - Líder TC", () => {
 
     await page.context().clearCookies();
     await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await validarMeuPerfilUsuarioCriado(page, { name, email });
 
     await page.goto("/admin", { waitUntil: "domcontentloaded" });
     await expect(page).not.toHaveURL(/\/login/);

--- a/testes/ui/usuarios/criar-usuario/lider-tc/criar-lider-tc.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/lider-tc/criar-lider-tc.ui.spec.ts
@@ -1,0 +1,46 @@
+﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
+import {
+  SENHA_USUARIO_NOVO,
+  aguardarUsuarioNaListaAdmin,
+  autenticarAdminParaCriacaoUsuario,
+  criarUsuarioViaApi,
+  loginDiretoUsuarioCriado,
+} from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+
+test.setTimeout(180000);
+
+test.describe("Criar usuário - Líder TC", () => {
+  const createdUserIds: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdUserIds) {
+      await request.delete(`${BASE_URL}/api/admin/users/${id}`).catch(() => {});
+    }
+  });
+
+  test("cria Líder TC, lista o usuário e valida login com acesso administrativo", async ({ page }) => {
+    const suffix = `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+    const email = `e2e-lider-tc-${suffix}@demo.test`;
+    const name = `Teste Líder TC ${suffix}`;
+
+    await autenticarAdminParaCriacaoUsuario(page);
+
+    const created = await criarUsuarioViaApi(page, {
+      name,
+      email,
+      role: "leader_tc",
+      password: SENHA_USUARIO_NOVO,
+    });
+
+    if (created.id) createdUserIds.push(created.id);
+
+    await aguardarUsuarioNaListaAdmin(page, email);
+
+    await page.context().clearCookies();
+    await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await page.goto("/admin", { waitUntil: "domcontentloaded" });
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});

--- a/testes/ui/usuarios/criar-usuario/suporte-tecnico/criar-suporte-tecnico.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/suporte-tecnico/criar-suporte-tecnico.ui.spec.ts
@@ -1,0 +1,46 @@
+﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
+import {
+  SENHA_USUARIO_NOVO,
+  aguardarUsuarioNaListaAdmin,
+  autenticarAdminParaCriacaoUsuario,
+  criarUsuarioViaApi,
+  loginDiretoUsuarioCriado,
+} from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+
+test.setTimeout(180000);
+
+test.describe("Criar usuário - Suporte Técnico", () => {
+  const createdUserIds: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdUserIds) {
+      await request.delete(`${BASE_URL}/api/admin/users/${id}`).catch(() => {});
+    }
+  });
+
+  test("cria Suporte Técnico, lista o usuário e valida login com acesso administrativo", async ({ page }) => {
+    const suffix = `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+    const email = `e2e-suporte-tecnico-${suffix}@demo.test`;
+    const name = `Teste Suporte Técnico ${suffix}`;
+
+    await autenticarAdminParaCriacaoUsuario(page);
+
+    const created = await criarUsuarioViaApi(page, {
+      name,
+      email,
+      role: "technical_support",
+      password: SENHA_USUARIO_NOVO,
+    });
+
+    if (created.id) createdUserIds.push(created.id);
+
+    await aguardarUsuarioNaListaAdmin(page, email);
+
+    await page.context().clearCookies();
+    await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await page.goto("/admin", { waitUntil: "domcontentloaded" });
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});

--- a/testes/ui/usuarios/criar-usuario/suporte-tecnico/criar-suporte-tecnico.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/suporte-tecnico/criar-suporte-tecnico.ui.spec.ts
@@ -1,4 +1,4 @@
-﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { test, expect } from "../../../../../support/fixtures/test";
 import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
 import {
   SENHA_USUARIO_NOVO,
@@ -7,6 +7,7 @@ import {
   criarUsuarioViaApi,
   loginDiretoUsuarioCriado,
 } from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+import { validarMeuPerfilUsuarioCriado } from "../../../../../support/functions/ui/usuarios/validar-meu-perfil-usuario-criado";
 
 test.setTimeout(180000);
 
@@ -39,6 +40,8 @@ test.describe("Criar usuário - Suporte Técnico", () => {
 
     await page.context().clearCookies();
     await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await validarMeuPerfilUsuarioCriado(page, { name, email });
 
     await page.goto("/admin", { waitUntil: "domcontentloaded" });
     await expect(page).not.toHaveURL(/\/login/);

--- a/testes/ui/usuarios/criar-usuario/usuario-empresa/criar-usuario-empresa.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/usuario-empresa/criar-usuario-empresa.ui.spec.ts
@@ -1,0 +1,51 @@
+﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
+import {
+  SENHA_USUARIO_NOVO,
+  aguardarUsuarioNaListaAdmin,
+  autenticarAdminParaCriacaoUsuario,
+  criarUsuarioViaApi,
+  loginDiretoUsuarioCriado,
+  validarSessaoUsuarioCriado,
+  validarBloqueioAdminParaPerfilCriado,
+  temEmpresaE2E,
+} from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+
+test.setTimeout(180000);
+
+test.describe("Criar usuário - Usuário da empresa", () => {
+  const createdUserIds: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdUserIds) {
+      await request.delete(`${BASE_URL}/api/admin/users/${id}`).catch(() => {});
+    }
+  });
+
+  test("cria Usuário da empresa, lista o usuário, valida login, empresa e bloqueio administrativo", async ({ page }) => {
+    const suffix = `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+    const email = `e2e-usuario-empresa-${suffix}@demo.test`;
+    const name = `Teste Usuário Empresa ${suffix}`;
+
+    await autenticarAdminParaCriacaoUsuario(page);
+
+    const created = await criarUsuarioViaApi(page, {
+      name,
+      email,
+      role: "company_user",
+      companySlug: "DEMO",
+      password: SENHA_USUARIO_NOVO,
+    });
+
+    if (created.id) createdUserIds.push(created.id);
+
+    await aguardarUsuarioNaListaAdmin(page, email);
+
+    await page.context().clearCookies();
+    await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    const me = await validarSessaoUsuarioCriado(page, email, "company_user");
+    expect(temEmpresaE2E(me)).toBeTruthy();
+    await validarBloqueioAdminParaPerfilCriado(page, "company_user");
+  });
+});

--- a/testes/ui/usuarios/criar-usuario/usuario-empresa/criar-usuario-empresa.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/usuario-empresa/criar-usuario-empresa.ui.spec.ts
@@ -1,4 +1,4 @@
-﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { test, expect } from "../../../../../support/fixtures/test";
 import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
 import {
   SENHA_USUARIO_NOVO,
@@ -10,6 +10,7 @@ import {
   validarBloqueioAdminParaPerfilCriado,
   temEmpresaE2E,
 } from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+import { validarMeuPerfilUsuarioCriado } from "../../../../../support/functions/ui/usuarios/validar-meu-perfil-usuario-criado";
 
 test.setTimeout(180000);
 
@@ -43,6 +44,8 @@ test.describe("Criar usuário - Usuário da empresa", () => {
 
     await page.context().clearCookies();
     await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await validarMeuPerfilUsuarioCriado(page, { name, email });
 
     const me = await validarSessaoUsuarioCriado(page, email, "company_user");
     expect(temEmpresaE2E(me)).toBeTruthy();

--- a/testes/ui/usuarios/criar-usuario/usuario-tc/criar-usuario-tc.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/usuario-tc/criar-usuario-tc.ui.spec.ts
@@ -1,4 +1,4 @@
-﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { test, expect } from "../../../../../support/fixtures/test";
 import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
 import {
   SENHA_USUARIO_NOVO,
@@ -9,6 +9,7 @@ import {
   validarSessaoUsuarioCriado,
   validarBloqueioAdminParaPerfilCriado,
 } from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+import { validarMeuPerfilUsuarioCriado } from "../../../../../support/functions/ui/usuarios/validar-meu-perfil-usuario-criado";
 
 test.setTimeout(180000);
 
@@ -42,6 +43,8 @@ test.describe("Criar usuário - Usuário TC", () => {
 
     await page.context().clearCookies();
     await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await validarMeuPerfilUsuarioCriado(page, { name, email });
 
     await validarSessaoUsuarioCriado(page, email, "testing_company_user");
     await validarBloqueioAdminParaPerfilCriado(page, "testing_company_user");

--- a/testes/ui/usuarios/criar-usuario/usuario-tc/criar-usuario-tc.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuario/usuario-tc/criar-usuario-tc.ui.spec.ts
@@ -1,0 +1,49 @@
+﻿import { test, expect } from "../../../../../support/fixtures/test";
+import { BASE_URL } from "../../../../../support/functions/api/autenticacao/autenticar-por-cookie";
+import {
+  SENHA_USUARIO_NOVO,
+  aguardarUsuarioNaListaAdmin,
+  autenticarAdminParaCriacaoUsuario,
+  criarUsuarioViaApi,
+  loginDiretoUsuarioCriado,
+  validarSessaoUsuarioCriado,
+  validarBloqueioAdminParaPerfilCriado,
+} from "../../../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
+
+test.setTimeout(180000);
+
+test.describe("Criar usuário - Usuário TC", () => {
+  const createdUserIds: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdUserIds) {
+      await request.delete(`${BASE_URL}/api/admin/users/${id}`).catch(() => {});
+    }
+  });
+
+  test("cria Usuário TC, lista o usuário, valida login e bloqueio administrativo", async ({ page }) => {
+    const suffix = `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+    const email = `e2e-usuario-tc-${suffix}@demo.test`;
+    const name = `Teste Usuário TC ${suffix}`;
+
+    await autenticarAdminParaCriacaoUsuario(page);
+
+    const created = await criarUsuarioViaApi(page, {
+      name,
+      email,
+      role: "testing_company_user",
+      companySlug: "DEMO",
+      password: SENHA_USUARIO_NOVO,
+    });
+
+    if (created.id) createdUserIds.push(created.id);
+
+    await aguardarUsuarioNaListaAdmin(page, email);
+
+    await page.context().clearCookies();
+    await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
+
+    await validarSessaoUsuarioCriado(page, email, "testing_company_user");
+    await validarBloqueioAdminParaPerfilCriado(page, "testing_company_user");
+  });
+});


### PR DESCRIPTION
## Resumo

- Separa a cobertura de criação de usuários por perfil em specs dedicados.
- Valida criação de Admin da empresa, Usuário da empresa, Usuário TC, Líder TC e Suporte Técnico.
- Confirma que o usuário criado aparece na listagem administrativa.
- Valida login do usuário criado.
- Valida /api/me.
- Valida visualmente /settings/profile, garantindo exibição de nome e e-mail no Meu Perfil.

## Validações executadas

- npm run typecheck -- --pretty false
- git diff --check
- npx playwright test testes/ui/usuarios/criar-usuario/empresa/criar-admin-empresa.ui.spec.ts testes/ui/usuarios/criar-usuario/lider-tc/criar-lider-tc.ui.spec.ts testes/ui/usuarios/criar-usuario/suporte-tecnico/criar-suporte-tecnico.ui.spec.ts testes/ui/usuarios/criar-usuario/usuario-empresa/criar-usuario-empresa.ui.spec.ts testes/ui/usuarios/criar-usuario/usuario-tc/criar-usuario-tc.ui.spec.ts --project=chromium --workers=1 --reporter=list,html

## Resultado

- 5 passed

## Observação

- Qase permaneceu desabilitado por ausência de token/configuração no ambiente local.