### PR TITLE
[codex] valida usuários por suporte Ana

### DIFF
--- a/app/admin/users/components/UserDetailsModal.tsx
+++ b/app/admin/users/components/UserDetailsModal.tsx
@@ -59,9 +59,21 @@ const normalizeRole = (value?: string | null): RoleValue => {
 };
 
 function canManageInstitutionalProfiles(
-  user?: { role?: string | null; permissionRole?: string | null; companyRole?: string | null } | null,
+  user?: {
+    role?: string | null;
+    permissionRole?: string | null;
+    companyRole?: string | null;
+    permissions?: Record<string, string[]> | null;
+  } | null,
 ) {
+  const canManageByPermission =
+    Array.isArray(user?.permissions?.users) &&
+    user.permissions.users.includes("edit") &&
+    Array.isArray(user?.permissions?.permissions) &&
+    user.permissions.permissions.includes("edit");
+
   return (
+    canManageByPermission ||
     normalizeEditableProfileRole(user?.role) === "leader_tc" ||
     normalizeEditableProfileRole(user?.permissionRole) === "leader_tc" ||
     normalizeEditableProfileRole(user?.companyRole) === "leader_tc"

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -73,7 +73,11 @@ function buildUniqueLogin(
   return `${base}.${counter}`;
 }
 
-function canManageInstitutionalProfiles(access: Awaited<ReturnType<typeof getAccessContext>> | null) {
+function canManageInstitutionalProfiles(
+  access: Awaited<ReturnType<typeof getAccessContext>> | null,
+  userAccess?: { canManagePrivilegedProfiles?: boolean } | null,
+) {
+  if (userAccess?.canManagePrivilegedProfiles) return true;
   if (!access) return false;
   const role = normalizeLegacyRole(access.role);
   const companyRole = normalizeLegacyRole(access.companyRole);
@@ -130,7 +134,7 @@ export async function POST(req: NextRequest) {
   if (!userAccess.canCreateUsers) {
     return NextResponse.json({ error: "Sem permissão para criar usuários" }, { status: 403 });
   }
-  const canManageProfiles = canManageInstitutionalProfiles(access);
+  const canManageProfiles = canManageInstitutionalProfiles(access, userAccess);
 
   const body = await req.json().catch(() => null);
   const profileFields = readSyncedUserProfileFields(body);
@@ -292,7 +296,7 @@ export async function PATCH(req: NextRequest) {
   if (!userAccess.canEditUsers) {
     return NextResponse.json({ error: "Sem permissão para editar usuários" }, { status: 403 });
   }
-  const canManageProfiles = canManageInstitutionalProfiles(access);
+  const canManageProfiles = canManageInstitutionalProfiles(access, userAccess);
 
   const body = await req.json().catch(() => null);
   const userId = typeof body?.id === "string" ? body.id : "";

--- a/lib/store/permissionsStore.ts
+++ b/lib/store/permissionsStore.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { mkdir, readFile, rename, writeFile } from "fs/promises";
+import { dirname, resolve } from "path";
 import { shouldUsePostgresPersistence } from "@/lib/persistenceMode";
 import { getPrismaClientOptions } from "@/lib/prismaClientOptions";
 import { isRedisConfigured } from "@/lib/redis";
@@ -32,6 +34,9 @@ async function getPrisma() {
 }
 
 const PREFIX = "qc:user_permissions:";
+const LOCAL_PERMISSIONS_FILE = process.env.LOCAL_AUTH_DATA_DIR
+  ? resolve(process.env.LOCAL_AUTH_DATA_DIR, "user-permissions-overrides.json")
+  : null;
 let memoryItems: UserPermissionsOverride[] = [];
 
 export type UserPermissionsOverride = {
@@ -117,11 +122,36 @@ async function pgListOverrides(): Promise<UserPermissionsOverride[]> {
 // ── Memory helpers (fallback) ──────────────────────────────────────────────
 
 async function readOverridesFile(): Promise<PermissionsOverrideFile> {
+  if (LOCAL_PERMISSIONS_FILE) {
+    try {
+      const parsed = JSON.parse(await readFile(LOCAL_PERMISSIONS_FILE, "utf8")) as PermissionsOverrideFile;
+      const items = Array.isArray(parsed?.items)
+        ? parsed.items
+            .map(normalizeStoredOverride)
+            .filter((item): item is UserPermissionsOverride => item !== null)
+        : [];
+      memoryItems = items;
+      return { items };
+    } catch {
+      return { items: memoryItems };
+    }
+  }
+
   return { items: memoryItems };
 }
 
 async function writeOverridesFile(store: PermissionsOverrideFile) {
-  memoryItems = store.items;
+  const items = store.items
+    .map(normalizeStoredOverride)
+    .filter((item): item is UserPermissionsOverride => item !== null);
+  memoryItems = items;
+
+  if (!LOCAL_PERMISSIONS_FILE) return;
+
+  await mkdir(dirname(LOCAL_PERMISSIONS_FILE), { recursive: true });
+  const temporaryFile = `${LOCAL_PERMISSIONS_FILE}.${process.pid}.tmp`;
+  await writeFile(temporaryFile, JSON.stringify({ items }, null, 2), "utf8");
+  await rename(temporaryFile, LOCAL_PERMISSIONS_FILE);
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────

--- a/support/functions/ui/usuarios/criar-usuario-por-perfil.ts
+++ b/support/functions/ui/usuarios/criar-usuario-por-perfil.ts
@@ -34,6 +34,8 @@ export async function criarUsuarioViaApi(
   payload: {
     name: string;
     email: string;
+    login?: string;
+    user?: string;
     role: string;
     companySlug?: string;
     password?: string;
@@ -43,8 +45,9 @@ export async function criarUsuarioViaApi(
     data: {
       name: payload.name,
       email: payload.email,
+      ...((payload.login ?? payload.user) ? { user: payload.login ?? payload.user } : {}),
       role: payload.role,
-      password: payload.password ?? SENHA_USUARIO_NOVO,
+      ...(payload.password !== undefined ? { password: payload.password } : {}),
       ...montarDadosEmpresaE2E(payload.role),
     },
   });

--- a/testes/api/login/esqueci-senha/password-reset-token-expiration.test.ts
+++ b/testes/api/login/esqueci-senha/password-reset-token-expiration.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const originalEnv = { ...process.env };
+
+let tempDir = "";
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+describe("codigo de redefinicao enviado por e-mail", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.useFakeTimers({ now: new Date("2026-06-23T12:00:00.000Z") });
+
+    tempDir = await mkdtemp(join(tmpdir(), "qc-reset-token-"));
+    delete process.env.DATABASE_URL;
+    delete process.env.PRISMA_DATABASE_URL;
+    delete process.env.POSTGRES_URL;
+    delete process.env.POSTGRES_PRISMA_URL;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    process.env.AUTH_STORE = "json";
+    process.env.LOCAL_AUTH_DATA_DIR = tempDir;
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    restoreEnv();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("expira apos 15 minutos", async () => {
+    const {
+      consumePasswordResetToken,
+      hasPasswordResetToken,
+      storePasswordResetToken,
+    } = await import("../../../../lib/auth/passwordResetToken");
+
+    const token = "codigo-email-expiravel";
+
+    await storePasswordResetToken(token, "usr_reset_email");
+
+    await expect(hasPasswordResetToken(token)).resolves.toBe(true);
+
+    jest.setSystemTime(new Date("2026-06-23T12:15:01.000Z"));
+
+    await expect(hasPasswordResetToken(token)).resolves.toBe(false);
+    await expect(consumePasswordResetToken(token)).resolves.toBeNull();
+  });
+});

--- a/testes/ui/usuarios/criar-usuarios-por-perfil.ui.spec.ts
+++ b/testes/ui/usuarios/criar-usuarios-por-perfil.ui.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { test, expect } from "../../../support/fixtures/test";
+import { PERMISSION_MODULES } from "../../../lib/permissionCatalog";
 import {
   SENHA_ADMIN_PADRAO,
   SENHA_USUARIO_NOVO,
@@ -17,8 +18,77 @@ import {
   temEmpresaE2E,
 } from "../../../support/functions/ui/usuarios/criar-usuario-por-perfil";
 import { BASE_URL, extrairCookie } from "../../../support/functions/api/autenticacao/autenticar-por-cookie";
+import {
+  esperarEmailCapturado,
+  limparEmailsCapturados,
+  type EmailCapturado,
+} from "../../../support/functions/api/solicitar-acesso/emails/capturar-emails";
+import { validarMeuPerfilUsuarioCriado } from "../../../support/functions/ui/usuarios/validar-meu-perfil-usuario-criado";
 
 test.setTimeout(180000);
+
+const PERMISSOES_COMPLETAS = Object.fromEntries(
+  PERMISSION_MODULES.map((module) => [module.id, module.actions]),
+);
+
+function gerarSufixo() {
+  return `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+}
+
+function conteudoEmail(email: EmailCapturado) {
+  return `${email.subject}\n${email.text ?? ""}\n${email.html}`;
+}
+
+function extrairSenhaTemporaria(email: EmailCapturado) {
+  const conteudo = conteudoEmail(email);
+  const textMatch = conteudo.match(/Senha:\s*([^\s<]+)/i);
+  const htmlMatch = conteudo.match(/<span class="cred-label">Senha<\/span>[\s\S]*?<span class="cred-value">([^<]+)<\/span>/i);
+  const senha = (textMatch?.[1] ?? htmlMatch?.[1] ?? "").trim();
+
+  expect(senha, "Senha temporaria deve estar presente no e-mail de boas-vindas").toBeTruthy();
+
+  return senha;
+}
+
+async function autenticarAnaSuporteTecnicoComAcessoCompleto(page: import("@playwright/test").Page) {
+  await autenticarAdminParaCriacaoUsuario(page);
+
+  const suffix = gerarSufixo();
+  const anaEmail = `ana.paula.lysyk+suporte-${suffix}@quality-control.test`;
+  const ana = await criarUsuarioViaApi(page, {
+    name: "Ana Paula Lysyk",
+    email: anaEmail,
+    login: `ana.paula.lysyk.suporte.${suffix}`,
+    role: "technical_support",
+    password: SENHA_USUARIO_NOVO,
+  });
+
+  expect(ana.id, "ID da Ana suporte tecnico E2E deve ser retornado").toBeTruthy();
+
+  const permissionResponse = await page.request.patch(`${BASE_URL}/api/admin/users/${ana.id}/permissions`, {
+    data: {
+      allow: PERMISSOES_COMPLETAS,
+      deny: {},
+    },
+  });
+  const permissionText = await permissionResponse.text();
+
+  expect(permissionResponse.status(), permissionText).toBe(200);
+
+  await page.context().clearCookies();
+  await loginDiretoUsuarioCriado(page, anaEmail, SENHA_USUARIO_NOVO);
+
+  const meResponse = await page.request.get(`${BASE_URL}/api/me`);
+  const me = await meResponse.json().catch(() => null);
+
+  expect(meResponse.status(), JSON.stringify(me)).toBe(200);
+  expect(me?.user?.role).toBe("technical_support");
+  expect(me?.user?.permissionRole).toBe("technical_support");
+  expect(me?.user?.permissions?.users).toEqual(expect.arrayContaining(["view", "create", "edit"]));
+  expect(me?.user?.permissions?.permissions).toEqual(expect.arrayContaining(["view", "edit"]));
+
+  return ana;
+}
 
 test.describe("Suporte Técnico — criação de perfis", () => {
   const createdUserIds: string[] = [];
@@ -30,39 +100,101 @@ test.describe("Suporte Técnico — criação de perfis", () => {
   });
 
   for (const profile of perfisCriadosPorSuporte) {
-    test(`Suporte TC cria perfil: ${profile.label}`, async ({ page }) => {
-      const suffix = `${Date.now().toString().slice(-6)}-${Math.random().toString(36).slice(2, 5)}`;
+    test(`Ana suporte TC cria, edita, recebe e-mail e acessa Meu Perfil: ${profile.label}`, async ({ page }) => {
+      const idsParaLimpar: string[] = [];
+      const suffix = gerarSufixo();
       const email = `e2e-sup-${profile.role}-${suffix}@demo.test`;
       const name = `Teste ${profile.label} ${suffix}`;
+      const editedName = `${name} Editado`;
 
-      await autenticarAdminParaCriacaoUsuario(page);
+      try {
+        limparEmailsCapturados();
 
-      const created = await criarUsuarioViaApi(page, {
-        name,
-        email,
-        role: profile.role,
-        companySlug: "DEMO",
-        password: SENHA_USUARIO_NOVO,
-      });
+        const ana = await autenticarAnaSuporteTecnicoComAcessoCompleto(page);
+        if (ana.id) {
+          idsParaLimpar.push(ana.id);
+        }
 
-      if (created.id) {
-        createdUserIds.push(created.id);
+        limparEmailsCapturados();
+
+        const created = await criarUsuarioViaApi(page, {
+          name,
+          email,
+          role: profile.role,
+          companySlug: "DEMO",
+        });
+
+        expect(created.id, `ID do usuario ${profile.label} deve ser retornado`).toBeTruthy();
+
+        if (created.id) {
+          createdUserIds.push(created.id);
+          idsParaLimpar.push(created.id);
+        }
+
+        await aguardarUsuarioNaListaAdmin(page, email);
+
+        const welcomeEmail = await esperarEmailCapturado({
+          to: email,
+          subject: /Seus dados de acesso - Quality Control/i,
+          contains: [
+            name,
+            "Quality Control",
+            "Login",
+            "Senha",
+            "temporária",
+            "Meu Perfil",
+            "Alterar Senha",
+          ],
+        });
+        const senhaTemporaria = extrairSenhaTemporaria(welcomeEmail);
+        expect(senhaTemporaria).not.toBe(SENHA_USUARIO_NOVO);
+
+        const createdItemResponse = await page.request.get(`${BASE_URL}/api/admin/users/${created.id}`);
+        const createdItemBody = await createdItemResponse.json().catch(() => null);
+        const clientId = createdItemBody?.item?.client_id ?? null;
+
+        const updateResponse = await page.request.patch(`${BASE_URL}/api/admin/users/${created.id}`, {
+          data: {
+            name: editedName,
+            full_name: editedName,
+            email,
+            phone: "51999990000",
+            role: profile.role,
+            client_id: clientId,
+          },
+        });
+        const updateText = await updateResponse.text();
+
+        expect(updateResponse.status(), updateText).toBe(200);
+
+        const updatedResponse = await page.request.get(`${BASE_URL}/api/admin/users/${created.id}`);
+        const updatedBody = await updatedResponse.json().catch(() => null);
+
+        expect(updatedResponse.status(), JSON.stringify(updatedBody)).toBe(200);
+        expect(updatedBody?.item?.name).toBe(editedName);
+        expect(updatedBody?.item?.phone).toBe("51999990000");
+        expect(updatedBody?.item?.permission_role).toBe(profile.role);
+
+        await page.context().clearCookies();
+
+        await loginDiretoUsuarioCriado(page, email, senhaTemporaria);
+
+        if (profile.role === "leader_tc" || profile.role === "technical_support") {
+          await page.goto("/admin", { waitUntil: "domcontentloaded" });
+          await expect(page).not.toHaveURL(/\/login/);
+        } else {
+          await validarSessaoUsuarioCriado(page, email, profile.role);
+        }
+
+        await validarMeuPerfilUsuarioCriado(page, { name: editedName, email });
+        await validarBloqueioAdminParaPerfilCriado(page, profile.role);
+      } finally {
+        await page.context().clearCookies();
+        await autenticarAdminParaCriacaoUsuario(page).catch(() => null);
+        for (const id of idsParaLimpar.reverse()) {
+          await page.request.delete(`${BASE_URL}/api/admin/users/${id}`).catch(() => {});
+        }
       }
-
-      await aguardarUsuarioNaListaAdmin(page, email);
-
-      await page.context().clearCookies();
-
-      await loginDiretoUsuarioCriado(page, email, SENHA_USUARIO_NOVO);
-
-      if (profile.role === "leader_tc" || profile.role === "technical_support") {
-        await page.goto("/admin", { waitUntil: "domcontentloaded" });
-        await expect(page).not.toHaveURL(/\/login/);
-      } else {
-        await validarSessaoUsuarioCriado(page, email, profile.role);
-      }
-
-      await validarBloqueioAdminParaPerfilCriado(page, profile.role);
     });
   }
 });


### PR DESCRIPTION
## O que mudou

- Valida o fluxo da Ana como perfil `technical_support` com permissões explícitas para criar e editar usuários.
- Cobre criação de Empresa, Usuário da Empresa, Usuário TC e Suporte Técnico, incluindo e-mail de acesso com senha temporária, edição cadastral e acesso ao Meu Perfil.
- Persiste overrides de permissões no fallback local `LOCAL_AUTH_DATA_DIR`, evitando que uma rota enxergue permissões diferentes de outra em E2E/dev.
- Adiciona teste unitário garantindo que o código/token enviado por e-mail para redefinição de senha expira após 15 minutos.

## Validação

- `npm run typecheck -- --pretty false`
- `npx playwright test testes/ui/usuarios/criar-usuarios-por-perfil.ui.spec.ts --project=chromium --grep "Ana suporte"`
- `npx playwright test testes/ui/usuarios/criar-usuarios-por-perfil.ui.spec.ts --project=chromium`
- `npx jest --config jest.config.ts --runInBand testes/api/login/esqueci-senha/password-reset-token-expiration.test.ts`