### PR TITLE
test(access-request): torna expiração do código de consulta configurável

### DIFF
--- a/lib/accessRequestsV2/accessKeyExpiration.ts
+++ b/lib/accessRequestsV2/accessKeyExpiration.ts
@@ -1,0 +1,35 @@
+﻿const DEFAULT_ACCESS_REQUEST_LOOKUP_CODE_TTL_MINUTES = 15;
+
+function readPositiveNumber(value: string | undefined) {
+  if (!value) return null;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+
+  return parsed;
+}
+
+export function getAccessRequestLookupCodeTtlMinutes() {
+  return (
+    readPositiveNumber(process.env.ACCESS_REQUEST_LOOKUP_CODE_TTL_MINUTES) ??
+    readPositiveNumber(process.env.ACCESS_REQUEST_ACCESS_KEY_TTL_MINUTES) ??
+    DEFAULT_ACCESS_REQUEST_LOOKUP_CODE_TTL_MINUTES
+  );
+}
+
+export function createAccessRequestLookupCodeExpiresAt(now = new Date()) {
+  const ttlMinutes = getAccessRequestLookupCodeTtlMinutes();
+  return new Date(now.getTime() + ttlMinutes * 60 * 1000).toISOString();
+}
+
+export function isAccessRequestLookupCodeExpired(
+  expiresAt?: string | null,
+  now = new Date(),
+) {
+  if (!expiresAt) return false;
+
+  const expiresAtTime = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtTime)) return false;
+
+  return expiresAtTime <= now.getTime();
+}

--- a/lib/accessRequestsV2/domain.ts
+++ b/lib/accessRequestsV2/domain.ts
@@ -162,6 +162,8 @@ export type AccessRequestV2 = {
   id: string;
   /** Chave pública de acesso segúro — enviada por e-mail, usada sem autenticação */
   accessKey?: string;
+  /** Data/hora de expiração do código de consulta enviado por e-mail */
+  accessKeyExpiresAt?: string;
   requesterUserId?: string;
   requesterEmail: string;
   requesterName?: string;

--- a/lib/accessRequestsV2/repository.ts
+++ b/lib/accessRequestsV2/repository.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomUUID } from "crypto";
 
+import { createAccessRequestLookupCodeExpiresAt } from "@/lib/accessRequestsV2/accessKeyExpiration";
 import {
   createAccessRequest,
   getAccessRequestById,
@@ -45,6 +46,8 @@ type V2Meta = {
   reviewComment?: string;
   /** Chave pública opaca para consulta sem login */
   accessKey?: string;
+  /** Data/hora de expiração do código de consulta */
+  accessKeyExpiresAt?: string;
   /** Campos sinalizados para ajuste pelo revisor */
   adjustmentFields?: AccessRequestAdjustmentField[];
   details?: AccessRequestV2Details;
@@ -81,6 +84,7 @@ function parseV2Message(message: string): V2Meta | null {
       reviewedAt: parsed.reviewedAt,
       reviewComment: parsed.reviewComment,
       accessKey: parsed.accessKey,
+      accessKeyExpiresAt: parsed.accessKeyExpiresAt,
       adjustmentFields: normalizeAccessRequestAdjustmentFields(parsed.adjustmentFields),
       details: parsed.details,
       adjustmentHistory: Array.isArray(parsed.adjustmentHistory) ? parsed.adjustmentHistory : [],
@@ -130,6 +134,7 @@ function mapPrismaRowToV2(row: {
   let requestedPasswordHash: string | undefined;
   let requestedCompanySlug: string | undefined;
   let accessKey: string | undefined;
+  let accessKeyExpiresAt: string | undefined;
   let adjustmentFields: AccessRequestAdjustmentField[] | undefined;
   let details: AccessRequestV2Details | undefined;
   let adjustmentHistory: AccessRequestAdjustmentRound[] | undefined;
@@ -149,6 +154,7 @@ function mapPrismaRowToV2(row: {
       requestedPasswordHash = meta.requestedPasswordHash;
       requestedCompanySlug = meta.requestedCompanySlug;
       accessKey = meta.accessKey;
+      accessKeyExpiresAt = meta.accessKeyExpiresAt;
       adjustmentFields = meta.adjustmentFields;
       details = meta.details;
       adjustmentHistory = meta.adjustmentHistory;
@@ -160,6 +166,7 @@ function mapPrismaRowToV2(row: {
   return {
     id: row.id,
     accessKey,
+    accessKeyExpiresAt,
     requesterUserId: row.userId ?? undefined,
     requesterEmail: row.email,
     requesterName: row.name ?? undefined,
@@ -214,6 +221,7 @@ export async function listAccessRequestsV2(filters?: {
         return {
           id: record.id,
           accessKey: meta.accessKey,
+          accessKeyExpiresAt: meta.accessKeyExpiresAt,
           requesterUserId: record.user_id ?? undefined,
           requesterEmail: meta.requesterEmail,
           requesterName: meta.requesterName,
@@ -352,6 +360,7 @@ export async function createAccessRequestV2(input: {
   const request: AccessRequestV2 = {
     id: randomUUID(),
     accessKey: randomBytes(20).toString("hex"),
+    accessKeyExpiresAt: createAccessRequestLookupCodeExpiresAt(),
     requesterUserId: input.requesterUserId,
     requesterEmail: input.requesterEmail,
     requesterName: input.requesterName,
@@ -387,6 +396,7 @@ export async function createAccessRequestV2(input: {
       adjustmentHistory: [],
       lastAdjustmentDiff: [],
       accessKey: request.accessKey,
+      accessKeyExpiresAt: request.accessKeyExpiresAt,
       createdAt: request.createdAt,
       updatedAt: request.updatedAt,
     };
@@ -426,6 +436,7 @@ export async function createAccessRequestV2(input: {
     adjustmentHistory: [],
     lastAdjustmentDiff: [],
     accessKey: request.accessKey,
+    accessKeyExpiresAt: request.accessKeyExpiresAt,
     createdAt: request.createdAt,
     updatedAt: request.updatedAt,
   };
@@ -493,6 +504,7 @@ export async function updateAccessRequestV2(
       reviewedAt: next.reviewedAt,
       reviewComment: next.reviewComment,
       accessKey: next.accessKey,
+      accessKeyExpiresAt: next.accessKeyExpiresAt,
       adjustmentFields: next.adjustmentFields,
       details: next.details,
       adjustmentHistory: next.adjustmentHistory,
@@ -536,6 +548,7 @@ export async function updateAccessRequestV2(
     reviewedAt: next.reviewedAt,
     reviewComment: next.reviewComment,
     accessKey: next.accessKey,
+    accessKeyExpiresAt: next.accessKeyExpiresAt,
     adjustmentFields: next.adjustmentFields,
     details: next.details,
     adjustmentHistory: next.adjustmentHistory,

--- a/lib/accessRequestsV2/service.ts
+++ b/lib/accessRequestsV2/service.ts
@@ -13,6 +13,7 @@ import {
   updateLocalUser,
 } from "@/lib/auth/localStore";
 import { hashPasswordSha256 } from "@/lib/passwordHash";
+import { isAccessRequestLookupCodeExpired } from "@/lib/accessRequestsV2/accessKeyExpiration";
 import { emailService } from "@/lib/email";
 import type { AuthUser } from "@/lib/jwtAuth";
 import { shouldUseJsonStore } from "@/lib/storeMode";
@@ -950,6 +951,7 @@ export async function updateAccessRequestByKey(
 ) {
   const request = await getAccessRequestV2ByKey(accessKey);
   if (!request) return null;
+  if (isAccessRequestLookupCodeExpired(request.accessKeyExpiresAt)) return null;
   if (request.status !== "needs_more_info") return "not-adjustable" as const;
 
   const allowedFields = normalizeAccessRequestAdjustmentFields(request.adjustmentFields);
@@ -1103,6 +1105,7 @@ export async function addPublicAccessRequestComment(input: {
 }) {
   const request = await getAccessRequestV2ByKey(input.accessKey);
   if (!request) return null;
+  if (isAccessRequestLookupCodeExpired(request.accessKeyExpiresAt)) return null;
   if (isAccessRequestFinalStatus(request.status)) return "final" as const;
   if (
     normalizeDuplicateValue(request.requesterEmail) !== normalizeDuplicateValue(input.email) ||
@@ -1122,6 +1125,18 @@ export async function addPublicAccessRequestComment(input: {
 export async function getPublicAccessRequestByKey(accessKey: string) {
   const request = await getAccessRequestV2ByKey(accessKey);
   if (!request) return null;
+
+  if (isAccessRequestLookupCodeExpired(request.accessKeyExpiresAt)) {
+    if (canTransitionAccessRequest(request.status, "expired")) {
+      await updateAccessRequestV2(request.id, {
+        status: "expired",
+        reviewComment: "Código de consulta expirado.",
+        adjustmentFields: [],
+      });
+    }
+    return null;
+  }
+
   const comments = await listAccessRequestComments(request.id);
   return { request, comments };
 }
@@ -1172,6 +1187,7 @@ export async function resendAccessRequestCode(input: { name: string; email: stri
       normalizeAccessRequestLookup(item.requesterEmail) === email,
   );
   if (!request?.accessKey) return false;
+  if (isAccessRequestLookupCodeExpired(request.accessKeyExpiresAt)) return false;
 
   const sent = await emailService.sendAccessRequestReceivedEmail(request.requesterEmail, {
     name: request.requesterName,

--- a/support/functions/api/solicitar-acesso/consulta/consultar-status.ts
+++ b/support/functions/api/solicitar-acesso/consulta/consultar-status.ts
@@ -31,7 +31,11 @@ export async function consultarSolicitacaoComTokenInvalido(request: APIRequestCo
     body,
     "GET /api/access-requests/by-key/:key - 404",
   );
-  expect(body?.message).toContain("Solicitação");
+  const normalizedMessage = String(body?.message ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+
+  expect(normalizedMessage).toContain("Solicitacao");
 
   return body;
 }
@@ -39,7 +43,7 @@ export async function consultarSolicitacaoComTokenInvalido(request: APIRequestCo
 export async function aprovarSolicitacaoViaApiV2(request: APIRequestContext, id: string) {
   const response = await request.post(`/api/access-requests/${id}/approve`, {
     data: {
-      comment: "Aprovado após validação dos dados.",
+      comment: "Aprovado apos validacao dos dados.",
     },
   });
 
@@ -54,7 +58,7 @@ export async function aprovarSolicitacaoViaApiV2(request: APIRequestContext, id:
 export async function recusarSolicitacaoViaApiV2(request: APIRequestContext, id: string) {
   const response = await request.post(`/api/access-requests/${id}/reject`, {
     data: {
-      comment: "Recusado por dados incompatíveis.",
+      comment: "Recusado por dados incompativeis.",
     },
   });
 
@@ -69,7 +73,7 @@ export async function recusarSolicitacaoViaApiV2(request: APIRequestContext, id:
 export async function solicitarAjusteViaApiV2(request: APIRequestContext, id: string) {
   const response = await request.post(`/api/access-requests/${id}/request-info`, {
     data: {
-      comment: "Corrigir telefone e descrição antes da aprovação.",
+      comment: "Corrigir telefone e descricao antes da aprovacao.",
       adjustmentFields: ["phone", "description"],
     },
   });

--- a/testes/api/solicitar-acesso/consulta/access-request-lookup-code-expiration.test.ts
+++ b/testes/api/solicitar-acesso/consulta/access-request-lookup-code-expiration.test.ts
@@ -1,0 +1,60 @@
+﻿const originalEnv = { ...process.env };
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+describe("codigo de consulta da solicitacao de acesso", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers({ now: new Date("2026-06-23T12:00:00.000Z") });
+    delete process.env.ACCESS_REQUEST_LOOKUP_CODE_TTL_MINUTES;
+    delete process.env.ACCESS_REQUEST_ACCESS_KEY_TTL_MINUTES;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    restoreEnv();
+  });
+
+  it("usa 15 minutos como tempo padrao de expiracao", async () => {
+    const { createAccessRequestLookupCodeExpiresAt } = await import(
+      "../../../../lib/accessRequestsV2/accessKeyExpiration"
+    );
+
+    const expiresAt = createAccessRequestLookupCodeExpiresAt();
+
+    expect(expiresAt).toBe("2026-06-23T12:15:00.000Z");
+  });
+
+  it("permite alterar o tempo de expiracao por variavel de ambiente", async () => {
+    process.env.ACCESS_REQUEST_LOOKUP_CODE_TTL_MINUTES = "1";
+
+    const { createAccessRequestLookupCodeExpiresAt } = await import(
+      "../../../../lib/accessRequestsV2/accessKeyExpiration"
+    );
+
+    const expiresAt = createAccessRequestLookupCodeExpiresAt();
+
+    expect(expiresAt).toBe("2026-06-23T12:01:00.000Z");
+  });
+
+  it("identifica codigo expirado pelo horario configurado", async () => {
+    const { isAccessRequestLookupCodeExpired } = await import(
+      "../../../../lib/accessRequestsV2/accessKeyExpiration"
+    );
+
+    const expiresAt = "2026-06-23T12:01:00.000Z";
+
+    expect(isAccessRequestLookupCodeExpired(expiresAt)).toBe(false);
+
+    jest.setSystemTime(new Date("2026-06-23T12:01:01.000Z"));
+
+    expect(isAccessRequestLookupCodeExpired(expiresAt)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Resumo

- Adiciona expiração configurável para o código de consulta da solicitação de acesso.
- Usa ACCESS_REQUEST_LOOKUP_CODE_TTL_MINUTES como variável principal.
- Mantém fallback de 15 minutos.
- Bloqueia consulta, ajuste, comentário público e reenvio quando o código estiver expirado.
- Ajusta validação do teste de token inválido para não depender de encoding/acento.

## Validações locais

- git diff --check
- npm run typecheck -- --pretty false
- npx jest --config jest.config.ts --runInBand testes/api/solicitar-acesso/consulta/access-request-lookup-code-expiration.test.ts
  - Resultado: 3 passed
- npx playwright test testes/api/solicitar-acesso/consulta/consultar-status.positivo.api.spec.ts --project=chromium --workers=1 --reporter=list
  - Resultado: 6 passed