### PR TITLE
feat: ajustar dashboards por perfil e empresa ativa

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -14,10 +14,11 @@ import { useClientContext } from "@/context/ClientContext";
 import { useDashboardContext } from "@/hooks/useDashboardContext";
 import { useDashboardFilters } from "@/hooks/useDashboardFilters";
 import { resolveActiveIdentity } from "@/lib/activeIdentity";
+import { buildCompanyPathForAccess } from "@/lib/companyRoutes";
 
 export default function DashboardClient() {
   const { user, loading: userLoading } = useAuthUser();
-  const { activeClient } = useClientContext();
+  const { activeClient, activeClientSlug } = useClientContext();
   const router = useRouter();
   const { metrics, loading: metricsLoading, error: metricsError } = useSystemMetrics();
 
@@ -46,12 +47,34 @@ export default function DashboardClient() {
 
   const safeUser: Partial<AuthUser> = user ?? {};
   const capabilities = (Array.isArray(safeUser.capabilities) ? safeUser.capabilities : []) as Capability[];
+  const permissionRole = typeof safeUser.permissionRole === "string" ? safeUser.permissionRole : null;
+  const role = typeof safeUser.role === "string" ? safeUser.role : null;
+  const companyRole = typeof safeUser.companyRole === "string" ? safeUser.companyRole : null;
+  const userOrigin =
+    typeof (safeUser as { userOrigin?: string | null }).userOrigin === "string"
+      ? (safeUser as { userOrigin?: string | null }).userOrigin ?? null
+      : typeof (safeUser as { user_origin?: string | null }).user_origin === "string"
+        ? (safeUser as { user_origin?: string | null }).user_origin ?? null
+        : null;
   const isGlobalAdmin = safeUser.isGlobalAdmin === true || safeUser.globalRole === "global_admin";
-  const normalizedRole = normalizeLegacyRole(
-    typeof safeUser.permissionRole === "string" ? safeUser.permissionRole : null,
-  ) ?? normalizeLegacyRole(typeof safeUser.role === "string" ? safeUser.role : null);
-  const canViewSystemMetrics = isGlobalAdmin || normalizedRole === SYSTEM_ROLES.TECHNICAL_SUPPORT;
-  const companySlug = typeof safeUser.companySlug === "string" ? safeUser.companySlug : null;
+  const normalizedRole =
+    normalizeLegacyRole(permissionRole) ??
+    normalizeLegacyRole(role) ??
+    normalizeLegacyRole(companyRole);
+  const canViewLeaderDashboard =
+    isGlobalAdmin ||
+    normalizedRole === SYSTEM_ROLES.LEADER_TC ||
+    normalizedRole === SYSTEM_ROLES.TECHNICAL_SUPPORT;
+  const scopedCompanySlug =
+    activeClientSlug ??
+    activeClient?.slug ??
+    (typeof safeUser.companySlug === "string" && safeUser.companySlug.trim() ? safeUser.companySlug.trim() : null) ??
+    (typeof (safeUser as { clientSlug?: string | null }).clientSlug === "string" &&
+    (safeUser as { clientSlug?: string | null }).clientSlug?.trim()
+      ? (safeUser as { clientSlug?: string | null }).clientSlug!.trim()
+      : null);
+  const companySlug = scopedCompanySlug;
+  const canViewSystemMetrics = canViewLeaderDashboard;
   const roleLabel = typeof safeUser.role === "string" && safeUser.role.trim() ? safeUser.role : "usuário";
   const activeIdentity = resolveActiveIdentity({ user: user ?? null, activeCompany: activeClient });
   const isCompanyIdentity = activeIdentity.kind === "company";
@@ -69,6 +92,34 @@ export default function DashboardClient() {
   })();
   const companyHomeHref = companySlug ? `/empresas/${encodeURIComponent(companySlug)}/home` : "/empresas";
   const runsHref = companySlug ? `/empresas/${encodeURIComponent(companySlug)}/runs` : "/runs";
+
+  useEffect(() => {
+    if (userLoading || !user || canViewLeaderDashboard) return;
+
+    const targetHref = scopedCompanySlug
+      ? buildCompanyPathForAccess(scopedCompanySlug, "dashboard", {
+          isGlobalAdmin,
+          permissionRole,
+          role,
+          companyRole,
+          userOrigin,
+          clientSlug: scopedCompanySlug,
+        })
+      : "/empresas";
+
+    router.replace(targetHref);
+  }, [
+    canViewLeaderDashboard,
+    companyRole,
+    isGlobalAdmin,
+    permissionRole,
+    role,
+    router,
+    scopedCompanySlug,
+    user,
+    userLoading,
+    userOrigin,
+  ]);
 
   const quickLinks = [
     {
@@ -177,6 +228,10 @@ export default function DashboardClient() {
     return <div className="tc-empty-state min-h-80">Redirecionando para login.</div>;
   }
 
+  if (!canViewLeaderDashboard) {
+    return <div className="tc-empty-state min-h-80">Redirecionando para o dashboard da empresa.</div>;
+  }
+
   return (
     <div className="min-h-screen bg-(--page-bg,#f3f6fb) text-(--page-text,#0b1a3c)">
       <div className="tc-page-shell py-4 sm:py-6">
@@ -228,11 +283,9 @@ export default function DashboardClient() {
 
                 <div className="tc-hero-copy">
                   <p className="tc-hero-kicker">Painel inicial</p>
-                  <h1 className="tc-hero-title">{isCompanyIdentity ? "Visão geral institucional" : "Visão geral do usuário"}</h1>
+                  <h1 className="tc-hero-title">Visão geral da liderança</h1>
                   <p className="tc-hero-description">
-                    {isCompanyIdentity
-                      ? "Acesso institucional da empresa ativa, com foco no contexto da organização e não em um usuário individual."
-                      : "Base inicial para navegar pela plataforma com o mesmo padrão visual das telas principais de administração."}
+                    Base inicial para liderança TC e suporte técnico acompanharem indicadores globais, qualidade e execução.
                   </p>
                 </div>
               </div>

--- a/app/hooks/navigation/useNavigationItems.ts
+++ b/app/hooks/navigation/useNavigationItems.ts
@@ -10,30 +10,76 @@ import { NAV_CATALOG, type NavItemDef, type NavModuleDef } from "@/lib/navigatio
 import { buildNavigationForUser, getNavigationRoute } from "@/lib/navigation/navigationPermissions";
 import type { SystemRole } from "@/lib/auth/roles";
 
-function resolveItemHref(
-  item: NavItemDef,
+const DISABLED_MODULE_IDS = new Set<NavModuleDef["id"]>(["operations"]);
+const INTERNAL_DASHBOARD_ROLES = new Set<SystemRole>([
+  SYSTEM_ROLES.LEADER_TC,
+  SYSTEM_ROLES.TECHNICAL_SUPPORT,
+]);
+const COMPANY_DASHBOARD_ROLES = new Set<SystemRole>([
+  SYSTEM_ROLES.EMPRESA,
+  SYSTEM_ROLES.COMPANY_USER,
+]);
+const ENABLED_NAV_CATALOG = NAV_CATALOG.filter((module) => !DISABLED_MODULE_IDS.has(module.id));
+
+function resolveCompanyRouteHref(
+  mappedPath: string | undefined,
+  fallbackHref: string | undefined,
   companySlug: string | null,
   companyRouteInput: Parameters<typeof buildCompanyPathForAccess>[2],
 ): string | undefined {
-  const mappedPath = getNavigationRoute(item)?.path;
   if (mappedPath?.includes("/empresas/[slug]/")) {
-    if (!companySlug) return item.href;
+    if (!companySlug) return fallbackHref;
     const companyRoute = mappedPath.split("/empresas/[slug]/")[1]?.split("?")[0];
     if (companyRoute) {
       return buildCompanyPathForAccess(companySlug, companyRoute, companyRouteInput);
     }
   }
-  return mappedPath ?? item.href;
+
+  return mappedPath ?? fallbackHref;
+}
+
+function resolveItemHref(
+  item: NavItemDef,
+  companySlug: string | null,
+  companyRouteInput: Parameters<typeof buildCompanyPathForAccess>[2],
+): string | undefined {
+  return resolveCompanyRouteHref(getNavigationRoute(item)?.path, item.href, companySlug, companyRouteInput);
+}
+
+function resolveModuleHref(
+  mod: NavModuleDef,
+  companySlug: string | null,
+  companyRouteInput: Parameters<typeof buildCompanyPathForAccess>[2],
+  effectiveRole: SystemRole | null,
+): string | undefined {
+  if (mod.id === "home") {
+    if (effectiveRole && INTERNAL_DASHBOARD_ROLES.has(effectiveRole)) {
+      return "/dashboard";
+    }
+
+    if (companySlug && effectiveRole && COMPANY_DASHBOARD_ROLES.has(effectiveRole)) {
+      return buildCompanyPathForAccess(companySlug, "dashboard", companyRouteInput);
+    }
+  }
+
+  return resolveCompanyRouteHref(getNavigationRoute(mod)?.path, mod.href, companySlug, companyRouteInput);
 }
 
 function resolveModuleItems(
   mod: NavModuleDef,
   companySlug: string | null,
   companyRouteInput: Parameters<typeof buildCompanyPathForAccess>[2],
+  effectiveRole: SystemRole | null,
 ): NavModuleDef {
+  const usesDashboardHome =
+    mod.id === "home" &&
+    effectiveRole != null &&
+    (INTERNAL_DASHBOARD_ROLES.has(effectiveRole) || COMPANY_DASHBOARD_ROLES.has(effectiveRole));
+
   return {
     ...mod,
-    href: getNavigationRoute(mod)?.path ?? mod.href,
+    label: usesDashboardHome ? "Dashboard" : mod.label,
+    href: resolveModuleHref(mod, companySlug, companyRouteInput, effectiveRole),
     items: mod.items.map((item) => ({
       ...item,
       href: resolveItemHref(item, companySlug, companyRouteInput),
@@ -85,7 +131,7 @@ export function useNavigationItems() {
           : typeof (user as { user_origin?: string | null } | null)?.user_origin === "string"
             ? (user as { user_origin?: string | null }).user_origin
             : null,
-      clientSlug: typeof user?.clientSlug === "string" ? user.clientSlug : activeClientSlug ?? null,
+      clientSlug: activeClientSlug ?? (typeof user?.clientSlug === "string" ? user.clientSlug : null),
     }),
     [activeClientSlug, isGlobalAdmin, user],
   );
@@ -101,7 +147,6 @@ export function useNavigationItems() {
       effectiveRole === SYSTEM_ROLES.COMPANY_USER
     ) {
       // They can see: home, quality, support, brain, documents
-      // (not companies/operations/automation/admin since those are TC-internal)
       return null; // will be handled below by isInstitutional
     }
     return effectiveRole;
@@ -123,16 +168,16 @@ export function useNavigationItems() {
       // Client profiles: home, quality, support, brain, documents only
       const CLIENT_MODULES = new Set(["home", "quality", "support", "brain", "documents"]);
       filtered = buildNavigationForUser(
-        NAV_CATALOG.filter((m) => CLIENT_MODULES.has(m.id)),
+        ENABLED_NAV_CATALOG.filter((m) => CLIENT_MODULES.has(m.id)),
         effectiveRole ?? SYSTEM_ROLES.COMPANY_USER,
         permissions,
         accessContext,
       );
     } else {
-      filtered = buildNavigationForUser(NAV_CATALOG, roleForFiltering, permissions, accessContext);
+      filtered = buildNavigationForUser(ENABLED_NAV_CATALOG, roleForFiltering, permissions, accessContext);
     }
 
-    return filtered.map((mod) => resolveModuleItems(mod, companySlug, companyRouteInput));
+    return filtered.map((mod) => resolveModuleItems(mod, companySlug, companyRouteInput, effectiveRole));
   }, [user, isClientProfile, effectiveRole, roleForFiltering, permissions, accessContext, companySlug, companyRouteInput]);
 
   return { modules, loading, companySlug, effectiveRole, isGlobalAdmin };


### PR DESCRIPTION
Resumo:
- Dashboard geral ficou restrito para líder TC e suporte técnico.
- Usuário vinculado à empresa passa a ser direcionado para o dashboard da empresa.
- O link Dashboard no menu muda conforme a empresa ativa selecionada.
- Operações continua fora do catálogo usado na navegação.

Status: mergeado na main.

Testes: não executado localmente neste ambiente.