### PR TITLE
Codex/agenda lider suporte contexto - resolvido

### DIFF
--- a/app/api/release-calendar/route.ts
+++ b/app/api/release-calendar/route.ts
@@ -1,15 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { getReleaseCalendarModel, type ReleaseCalendarEvent } from "@/data/releaseCalendarModel";
+import {
+  getReleaseCalendarModel,
+  type ReleaseCalendarAudienceProfile,
+  type ReleaseCalendarContext,
+  type ReleaseCalendarCriticality,
+  type ReleaseCalendarEvent,
+} from "@/data/releaseCalendarModel";
+import { NO_STORE_HEADERS } from "@/lib/http/noStore";
+import { authenticateRequest } from "@/lib/jwtAuth";
 import { createNotificationEvent, type NotificationEventRecipient } from "@/lib/notificationEventsStore";
 import { getReleaseCalendarSummary, listReleaseCalendarEvents, updateReleaseCalendarEventStatus, upsertReleaseCalendarEvent } from "@/lib/releaseCalendarStore";
-import { authenticateRequest } from "@/lib/jwtAuth";
-import { NO_STORE_HEADERS } from "@/lib/http/noStore";
 
 export const runtime = "nodejs";
 export const revalidate = 0;
 
 const VALID_STATUSES = ["planned", "at_risk", "blocked", "done", "cancelled"] as const;
+const VALID_CRITICALITIES = ["critical", "high", "normal", "low"] as const;
+const VALID_CONTEXTS = ["company", "project", "user", "tc", "support", "release", "delivery"] as const;
+const VALID_AUDIENCE_PROFILES = [
+  "all",
+  "empresa",
+  "company_user",
+  "testing_company_user",
+  "leader_tc",
+  "technical_support",
+  "release_actor",
+  "brain",
+] as const;
 
 type ReleaseStatus = (typeof VALID_STATUSES)[number];
 
@@ -17,11 +35,34 @@ function normalizeStatus(value: unknown): ReleaseStatus | null {
   return typeof value === "string" && VALID_STATUSES.includes(value as ReleaseStatus) ? (value as ReleaseStatus) : null;
 }
 
+function normalizeCriticality(value: unknown): ReleaseCalendarCriticality | null {
+  return typeof value === "string" && VALID_CRITICALITIES.includes(value as ReleaseCalendarCriticality) ? (value as ReleaseCalendarCriticality) : null;
+}
+
+function normalizeContext(value: unknown): ReleaseCalendarContext | null {
+  return typeof value === "string" && VALID_CONTEXTS.includes(value as ReleaseCalendarContext) ? (value as ReleaseCalendarContext) : null;
+}
+
+function normalizeAudienceProfile(value: unknown): ReleaseCalendarAudienceProfile | null {
+  return typeof value === "string" && VALID_AUDIENCE_PROFILES.includes(value as ReleaseCalendarAudienceProfile)
+    ? (value as ReleaseCalendarAudienceProfile)
+    : null;
+}
+
 function actorName(user: { name?: string | null; email?: string | null; id: string }) {
   return user.name ?? user.email ?? user.id;
 }
 
 function buildRecipients(user: { name?: string | null; email?: string | null; id: string }, event: ReleaseCalendarEvent): NotificationEventRecipient[] {
+  const profileRecipients = event.audienceProfiles
+    .filter((profileKind) => profileKind !== "brain")
+    .map((profileKind) => ({
+      recipientId: `${profileKind}:${event.companySlug ?? event.projectSlug ?? event.releaseId}`,
+      recipientName: profileKind,
+      profileKind,
+      channels: ["in_app", "brain"] as NotificationEventRecipient["channels"],
+    }));
+
   return [
     {
       recipientId: user.id,
@@ -29,6 +70,7 @@ function buildRecipients(user: { name?: string | null; email?: string | null; id
       profileKind: "release_actor",
       channels: ["in_app", "brain"],
     },
+    ...profileRecipients,
     {
       recipientId: "brain",
       recipientName: "Brain",
@@ -64,6 +106,9 @@ async function recordCalendarNotification(input: {
       calendarEventType: input.event.type,
       calendarStatus: input.event.status,
       calendarCriticality: input.event.criticality,
+      calendarContext: input.event.context,
+      calendarAudienceProfiles: input.event.audienceProfiles,
+      calendarParticipants: input.event.participantNames,
       startAt: input.event.startAt,
       endAt: input.event.endAt,
     },
@@ -76,10 +121,14 @@ export async function GET(req: NextRequest) {
   const companySlug = url.searchParams.get("companySlug")?.trim() || null;
   const projectSlug = url.searchParams.get("projectSlug")?.trim() || null;
   const releaseId = url.searchParams.get("releaseId")?.trim() || null;
+  const ownerName = url.searchParams.get("ownerName")?.trim() || null;
   const status = normalizeStatus(url.searchParams.get("status")?.trim() || null);
+  const criticality = normalizeCriticality(url.searchParams.get("criticality")?.trim() || null);
+  const context = normalizeContext(url.searchParams.get("context")?.trim() || null);
+  const audienceProfile = normalizeAudienceProfile(url.searchParams.get("audienceProfile")?.trim() || null);
 
   const [events, summary] = await Promise.all([
-    listReleaseCalendarEvents({ companySlug, projectSlug, releaseId, status }),
+    listReleaseCalendarEvents({ companySlug, projectSlug, releaseId, ownerName, status, criticality, context, audienceProfile }),
     getReleaseCalendarSummary(),
   ]);
 
@@ -108,7 +157,7 @@ export async function POST(req: NextRequest) {
         event,
         user,
         title: `Evento critico criado: ${event.title}`,
-        description: `Evento critico da release ${event.releaseName} foi cadastrado na agenda.`,
+        description: `Evento critico da release ${event.releaseName} foi cadastrado na agenda para ${event.audienceProfiles.join(", ")}.`,
       })
     : null;
 

--- a/data/releaseCalendarModel.ts
+++ b/data/releaseCalendarModel.ts
@@ -13,6 +13,16 @@ export type ReleaseCalendarEventType =
 
 export type ReleaseCalendarStatus = "planned" | "at_risk" | "blocked" | "done" | "cancelled";
 export type ReleaseCalendarCriticality = "critical" | "high" | "normal" | "low";
+export type ReleaseCalendarContext = "company" | "project" | "user" | "tc" | "support" | "release" | "delivery";
+export type ReleaseCalendarAudienceProfile =
+  | "all"
+  | "empresa"
+  | "company_user"
+  | "testing_company_user"
+  | "leader_tc"
+  | "technical_support"
+  | "release_actor"
+  | "brain";
 
 export type ReleaseCalendarEvent = {
   id: string;
@@ -20,6 +30,9 @@ export type ReleaseCalendarEvent = {
   type: ReleaseCalendarEventType;
   status: ReleaseCalendarStatus;
   criticality: ReleaseCalendarCriticality;
+  context: ReleaseCalendarContext;
+  markerLabel: string;
+  audienceProfiles: ReleaseCalendarAudienceProfile[];
   companyId: string | null;
   companySlug: string | null;
   companyName: string | null;
@@ -31,6 +44,7 @@ export type ReleaseCalendarEvent = {
   endAt: string;
   ownerId: string | null;
   ownerName: string | null;
+  participantNames: string[];
   description: string;
   checklist: string[];
   notificationRules: string[];
@@ -55,11 +69,22 @@ export const releaseCalendarRules: ReleaseCalendarRule[] = [
   {
     id: "single-release-calendar",
     title: "Calendario unico de entrega",
-    description: "Toda entrega precisa aparecer em um calendario operacional por empresa, projeto e release.",
+    description: "Toda entrega precisa aparecer em um calendario operacional por empresa, projeto, usuario responsavel e release.",
     acceptanceCriteria: [
       "Release deve ter data de escopo, freeze, janela de QA, homologacao, entrega e pos-release quando aplicavel.",
-      "Agenda deve permitir filtrar por empresa, projeto, status e criticidade.",
-      "Brain deve conseguir responder o que entrega quando e o que esta em risco.",
+      "Agenda deve permitir filtrar por empresa, projeto, status, criticidade, contexto e responsavel.",
+      "Lider TC e Suporte Tecnico enxergam a agenda consolidada sem precisar trocar de empresa manualmente.",
+      "Brain deve conseguir responder o que entrega quando, quem esta responsavel e o que esta em risco.",
+    ],
+  },
+  {
+    id: "leader-support-overview",
+    title: "Visao consolidada para Lider TC e Suporte Tecnico",
+    description: "Perfis internos da TC precisam ver marcacoes de empresas, projetos e usuarios em uma camada visual compacta.",
+    acceptanceCriteria: [
+      "Marcacoes devem informar contexto, responsavel e publico-alvo.",
+      "Calendario deve agrupar eventos por dia e esconder excesso com contador de mais marcacoes.",
+      "Ao clicar em um dia, a tela exibe as marcacoes daquele dia com detalhes operacionais.",
     ],
   },
   {
@@ -89,7 +114,7 @@ export const releaseCalendarRules: ReleaseCalendarRule[] = [
     acceptanceCriteria: [
       "Evento de agenda gera notificacao mesmo que entrega seja suprimida.",
       "Eventos criticos de release nao devem ser silenciados sem registro.",
-      "Brain recebe contexto de prazo e risco.",
+      "Brain recebe contexto de prazo, responsavel, publico-alvo e risco.",
     ],
   },
 ];
@@ -119,6 +144,12 @@ export const releaseCalendarMetrics: ReleaseCalendarMetric[] = [
     formula: "calendar_events_with_notifications / total_calendar_events",
     description: "Mostra se os prazos estao gerando avisos e lembretes.",
   },
+  {
+    id: "calendar-context-coverage",
+    label: "Cobertura por contexto",
+    formula: "count(calendar_events grouped by context)",
+    description: "Mostra se a agenda esta distribuida entre empresa, projeto, usuario, TC, suporte e entrega.",
+  },
 ];
 
 export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
@@ -128,6 +159,9 @@ export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
     type: "scope_cut",
     status: "planned",
     criticality: "high",
+    context: "project",
+    markerLabel: "Escopo",
+    audienceProfiles: ["leader_tc", "technical_support", "testing_company_user"],
     companyId: null,
     companySlug: null,
     companyName: null,
@@ -139,6 +173,7 @@ export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
     endAt: "2026-07-01T10:00:00.000-03:00",
     ownerId: null,
     ownerName: "Produto/Tech Lead",
+    participantNames: ["QA", "Produto"],
     description: "Fechar o que entra e o que fica fora da release.",
     checklist: ["Lista de tickets fechada", "Critérios de aceite revisados", "Riscos conhecidos registrados"],
     notificationRules: ["Avisar lideres e QA", "Gerar lembrete 24h antes", "Gerar alerta se escopo mudar depois do corte"],
@@ -150,6 +185,9 @@ export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
     type: "qa_window",
     status: "planned",
     criticality: "critical",
+    context: "user",
+    markerLabel: "QA",
+    audienceProfiles: ["leader_tc", "technical_support", "testing_company_user"],
     companyId: null,
     companySlug: null,
     companyName: null,
@@ -161,6 +199,7 @@ export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
     endAt: "2026-07-03T18:00:00.000-03:00",
     ownerId: null,
     ownerName: "QA",
+    participantNames: ["QA", "Suporte Tecnico"],
     description: "Executar aceite, regressao e validacoes criticas antes da entrega.",
     checklist: ["Plano de teste criado", "Runs abertas", "Bugs criticos triados", "Evidencias anexadas"],
     notificationRules: ["Avisar inicio da janela", "Avisar bloqueios", "Avisar fim da janela"],
@@ -172,6 +211,9 @@ export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
     type: "release",
     status: "planned",
     criticality: "critical",
+    context: "delivery",
+    markerLabel: "Entrega",
+    audienceProfiles: ["all"],
     companyId: null,
     companySlug: null,
     companyName: null,
@@ -183,6 +225,7 @@ export const releaseCalendarTemplates: ReleaseCalendarEvent[] = [
     endAt: "2026-07-04T12:00:00.000-03:00",
     ownerId: null,
     ownerName: "Release Manager",
+    participantNames: ["Lider TC", "Suporte Tecnico", "Empresa"],
     description: "Publicar a versao e acompanhar a estabilizacao inicial.",
     checklist: ["Go/no-go confirmado", "Plano de rollback revisado", "Comunicacao enviada", "Monitoramento ativo"],
     notificationRules: ["Avisar todos os envolvidos", "Avisar status final", "Avisar incidente pos-release"],
@@ -208,12 +251,25 @@ export function getReleaseCalendarModel() {
       "post_release",
     ] satisfies ReleaseCalendarEventType[],
     statuses: ["planned", "at_risk", "blocked", "done", "cancelled"] satisfies ReleaseCalendarStatus[],
+    contexts: ["company", "project", "user", "tc", "support", "release", "delivery"] satisfies ReleaseCalendarContext[],
+    audienceProfiles: [
+      "all",
+      "empresa",
+      "company_user",
+      "testing_company_user",
+      "leader_tc",
+      "technical_support",
+      "release_actor",
+      "brain",
+    ] satisfies ReleaseCalendarAudienceProfile[],
     summary: {
       rules: releaseCalendarRules.length,
       metrics: releaseCalendarMetrics.length,
       templates: releaseCalendarTemplates.length,
       eventTypes: 9,
       statuses: 5,
+      contexts: 7,
+      audienceProfiles: 8,
     },
   };
 }

--- a/lib/releaseCalendarStore.ts
+++ b/lib/releaseCalendarStore.ts
@@ -2,8 +2,17 @@ import "server-only";
 
 import { randomUUID } from "crypto";
 
+import {
+  releaseCalendarTemplates,
+  type ReleaseCalendarAudienceProfile,
+  type ReleaseCalendarContext,
+  type ReleaseCalendarCriticality,
+  type ReleaseCalendarEvent,
+  type ReleaseCalendarEventType,
+  type ReleaseCalendarStatus,
+} from "@/data/releaseCalendarModel";
+
 import { getRedis } from "@/lib/redis";
-import { releaseCalendarTemplates, type ReleaseCalendarEvent, type ReleaseCalendarEventType, type ReleaseCalendarStatus } from "@/data/releaseCalendarModel";
 
 export type ReleaseCalendarEventInput = Partial<Omit<ReleaseCalendarEvent, "id">> & {
   id?: string;
@@ -21,6 +30,32 @@ type ReleaseCalendarStore = {
 
 const STORE_KEY = "qc:release_calendar:v1";
 
+const VALID_EVENT_TYPES: ReleaseCalendarEventType[] = [
+  "discovery",
+  "scope_cut",
+  "dev_freeze",
+  "qa_window",
+  "bug_bash",
+  "uat",
+  "release_candidate",
+  "release",
+  "post_release",
+];
+
+const VALID_STATUSES: ReleaseCalendarStatus[] = ["planned", "at_risk", "blocked", "done", "cancelled"];
+const VALID_CRITICALITIES: ReleaseCalendarCriticality[] = ["critical", "high", "normal", "low"];
+const VALID_CONTEXTS: ReleaseCalendarContext[] = ["company", "project", "user", "tc", "support", "release", "delivery"];
+const VALID_AUDIENCE_PROFILES: ReleaseCalendarAudienceProfile[] = [
+  "all",
+  "empresa",
+  "company_user",
+  "testing_company_user",
+  "leader_tc",
+  "technical_support",
+  "release_actor",
+  "brain",
+];
+
 function emptyStore(): ReleaseCalendarStore {
   return { events: [] };
 }
@@ -35,19 +70,52 @@ function nullableText(value: unknown, max = 240) {
 }
 
 function sanitizeList(value: unknown, maxItems = 12) {
-  if (!Array.isArray(value)) return [];
-  return value
+  const source = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(/\n|,/g)
+      : [];
+
+  return source
     .map((item) => sanitizeText(item, 240))
     .filter(Boolean)
     .slice(0, maxItems);
 }
 
 function isEventType(value: string): value is ReleaseCalendarEventType {
-  return ["discovery", "scope_cut", "dev_freeze", "qa_window", "bug_bash", "uat", "release_candidate", "release", "post_release"].includes(value);
+  return VALID_EVENT_TYPES.includes(value as ReleaseCalendarEventType);
 }
 
 function isStatus(value: string): value is ReleaseCalendarStatus {
-  return ["planned", "at_risk", "blocked", "done", "cancelled"].includes(value);
+  return VALID_STATUSES.includes(value as ReleaseCalendarStatus);
+}
+
+function isCriticality(value: string): value is ReleaseCalendarCriticality {
+  return VALID_CRITICALITIES.includes(value as ReleaseCalendarCriticality);
+}
+
+function isContext(value: string): value is ReleaseCalendarContext {
+  return VALID_CONTEXTS.includes(value as ReleaseCalendarContext);
+}
+
+function isAudienceProfile(value: string): value is ReleaseCalendarAudienceProfile {
+  return VALID_AUDIENCE_PROFILES.includes(value as ReleaseCalendarAudienceProfile);
+}
+
+function normalizeAudienceProfiles(value: unknown): ReleaseCalendarAudienceProfile[] {
+  const profiles = sanitizeList(value, 8)
+    .map((item) => item.toLowerCase())
+    .filter(isAudienceProfile);
+
+  return profiles.length ? Array.from(new Set(profiles)) : ["leader_tc", "technical_support", "release_actor"];
+}
+
+function inferContext(input: Partial<ReleaseCalendarEvent>): ReleaseCalendarContext {
+  if (sanitizeText(input.context) && isContext(sanitizeText(input.context))) return sanitizeText(input.context) as ReleaseCalendarContext;
+  if (nullableText(input.ownerId) || nullableText(input.ownerName) || sanitizeList(input.participantNames).length) return "user";
+  if (nullableText(input.projectId) || nullableText(input.projectSlug)) return "project";
+  if (nullableText(input.companyId) || nullableText(input.companySlug) || nullableText(input.companyName)) return "company";
+  return input.type === "release" ? "delivery" : "release";
 }
 
 function normalizeEvent(input: Partial<ReleaseCalendarEvent> | null | undefined): ReleaseCalendarEvent | null {
@@ -61,12 +129,17 @@ function normalizeEvent(input: Partial<ReleaseCalendarEvent> | null | undefined)
 
   const status = sanitizeText(input?.status);
   const criticality = sanitizeText(input?.criticality);
+  const context = inferContext(input ?? {});
+  const markerLabel = sanitizeText(input?.markerLabel, 48) || title;
   return {
     id: sanitizeText(input?.id, 120) || randomUUID(),
     title,
     type,
     status: isStatus(status) ? status : "planned",
-    criticality: criticality === "critical" || criticality === "high" || criticality === "low" ? criticality : "normal",
+    criticality: isCriticality(criticality) ? criticality : "normal",
+    context,
+    markerLabel,
+    audienceProfiles: normalizeAudienceProfiles(input?.audienceProfiles),
     companyId: nullableText(input?.companyId),
     companySlug: nullableText(input?.companySlug),
     companyName: nullableText(input?.companyName),
@@ -78,6 +151,7 @@ function normalizeEvent(input: Partial<ReleaseCalendarEvent> | null | undefined)
     endAt,
     ownerId: nullableText(input?.ownerId),
     ownerName: nullableText(input?.ownerName),
+    participantNames: sanitizeList(input?.participantNames, 16),
     description: sanitizeText(input?.description, 800),
     checklist: sanitizeList(input?.checklist),
     notificationRules: sanitizeList(input?.notificationRules),
@@ -107,20 +181,46 @@ async function writeStore(store: ReleaseCalendarStore) {
   await redis.set(STORE_KEY, JSON.stringify(store));
 }
 
+function textMatches(value: string | null | undefined, needle: string) {
+  if (!needle) return true;
+  return (value ?? "").toLowerCase().includes(needle.toLowerCase());
+}
+
+function audienceMatches(event: ReleaseCalendarEvent, audienceProfile?: ReleaseCalendarAudienceProfile | null) {
+  if (!audienceProfile) return true;
+  return event.audienceProfiles.includes("all") || event.audienceProfiles.includes(audienceProfile);
+}
+
 export async function listReleaseCalendarEvents(options: {
   companySlug?: string | null;
   projectSlug?: string | null;
   releaseId?: string | null;
   status?: ReleaseCalendarStatus | null;
+  criticality?: ReleaseCalendarCriticality | null;
+  context?: ReleaseCalendarContext | null;
+  audienceProfile?: ReleaseCalendarAudienceProfile | null;
+  ownerName?: string | null;
 } = {}) {
   const store = await readStore();
   const source = store.events.length ? store.events : releaseCalendarTemplates;
+  const ownerNeedle = sanitizeText(options.ownerName);
+
   return source
     .filter((event) => {
       if (options.companySlug && event.companySlug !== options.companySlug) return false;
       if (options.projectSlug && event.projectSlug !== options.projectSlug) return false;
       if (options.releaseId && event.releaseId !== options.releaseId) return false;
       if (options.status && event.status !== options.status) return false;
+      if (options.criticality && event.criticality !== options.criticality) return false;
+      if (options.context && event.context !== options.context) return false;
+      if (!audienceMatches(event, options.audienceProfile)) return false;
+      if (
+        ownerNeedle &&
+        !textMatches(event.ownerName, ownerNeedle) &&
+        !event.participantNames.some((participant) => textMatches(participant, ownerNeedle))
+      ) {
+        return false;
+      }
       return true;
     })
     .sort((left, right) => left.startAt.localeCompare(right.startAt));
@@ -147,6 +247,16 @@ export async function updateReleaseCalendarEventStatus(id: string, status: Relea
 
 export async function getReleaseCalendarSummary() {
   const events = await listReleaseCalendarEvents();
+  const companies = new Set(events.map((event) => event.companySlug ?? event.companyName).filter(Boolean));
+  const projects = new Set(events.map((event) => event.projectSlug).filter(Boolean));
+  const users = new Set(
+    events
+      .flatMap((event) => [event.ownerName, ...event.participantNames])
+      .map((value) => value?.trim())
+      .filter(Boolean),
+  );
+  const contexts = new Set(events.map((event) => event.context).filter(Boolean));
+
   return {
     total: events.length,
     planned: events.filter((event) => event.status === "planned").length,
@@ -156,5 +266,11 @@ export async function getReleaseCalendarSummary() {
     critical: events.filter((event) => event.criticality === "critical").length,
     releases: new Set(events.map((event) => event.releaseId)).size,
     qaWindows: events.filter((event) => event.type === "qa_window").length,
+    companies: companies.size,
+    projects: projects.size,
+    users: users.size,
+    contexts: contexts.size,
+    leaderVisible: events.filter((event) => audienceMatches(event, "leader_tc")).length,
+    supportVisible: events.filter((event) => audienceMatches(event, "technical_support")).length,
   };
 }


### PR DESCRIPTION
PR limpo criado a partir da main atual para evitar o conflito do ReleaseCalendarPanel.tsx. Mantem a agenda para Lider TC/Suporte Tecnico e preserva as classes de tema/personality do menu e dos campos.